### PR TITLE
Add feature for imported frequency dictionaries in dictionary entries

### DIFF
--- a/Shiori Reader/Features/Dictionary/DictionaryEntry.swift
+++ b/Shiori Reader/Features/Dictionary/DictionaryEntry.swift
@@ -44,7 +44,7 @@ struct DictionaryEntry: Identifiable, Equatable {
     var transformationNotes: String? = nil
     let popularity: Double?
     let source: String // Dictionary source identifier (e.g., "jmdict")
-    var frequencyData: FrequencyData? = nil // BCCWJ frequency data
+    var frequencyData: [FrequencyData] = [] // BCCWJ frequency data
     
     // Lazy loading helper
     private let pitchAccentLoader: PitchAccentLoader
@@ -60,7 +60,7 @@ struct DictionaryEntry: Identifiable, Equatable {
     }
     
     // Custom initializer to set up lazy loader
-    init(id: String, term: String, reading: String, meanings: [String], meaningTags: [String], termTags: [String], score: String?, rules: String?, transformed: String? = nil, transformationNotes: String? = nil, popularity: Double?, source: String = "jmdict", frequencyData: FrequencyData? = nil) {
+    init(id: String, term: String, reading: String, meanings: [String], meaningTags: [String], termTags: [String], score: String?, rules: String?, transformed: String? = nil, transformationNotes: String? = nil, popularity: Double?, source: String = "jmdict", frequencyData: [FrequencyData] = []) {
         self.id = id
         self.term = term
         self.reading = reading
@@ -89,8 +89,8 @@ struct DictionaryEntry: Identifiable, Equatable {
                lhs.transformed == rhs.transformed &&
                lhs.transformationNotes == rhs.transformationNotes &&
                lhs.popularity == rhs.popularity &&
-               lhs.source == rhs.source &&
-               lhs.frequencyData?.word == rhs.frequencyData?.word
+               lhs.source == rhs.source // &&
+//             lhs.frequencyData?.word == rhs.frequencyData?.word
     }
     
     /// Returns true if this entry has pitch accent information
@@ -110,20 +110,21 @@ struct DictionaryEntry: Identifiable, Equatable {
     }
     
     /// Returns frequency rank as a formatted string for display
-    var frequencyRankString: String? {
-        guard let freqData = frequencyData else { return nil }
+    var frequencyRankStrings: [String] {
+        var freqRanks: [String] = [];
         
-        if freqData.rank > 0 {
-            return "\(freqData.rank)"
-        } else if freqData.frequency > 0 {
-            return "\(freqData.frequency)"
+        frequencyData.forEach { freqData in
+            if freqData.rank > 0 {
+                freqRanks.append("\(freqData.rank)")
+            } else if freqData.frequency > 0 {
+                freqRanks.append("\(freqData.frequency)")
+            }
         }
-        
-        return nil
+        return freqRanks
     }
     
     /// Returns true if this entry has frequency data
     var hasFrequencyData: Bool {
-        return frequencyData != nil
+        return frequencyData.count > 0
     }
 }

--- a/Shiori Reader/Features/DictionaryImport/DictionaryImportManager.swift
+++ b/Shiori Reader/Features/DictionaryImport/DictionaryImportManager.swift
@@ -3,28 +3,28 @@ import GRDB
 
 /// Manages the import of Yomitan dictionaries and integrates with the existing DictionaryManager
 class DictionaryImportManager: ObservableObject {
-
+    
     static let shared = DictionaryImportManager()
-
+    
     @Published var isImporting = false
     @Published var importProgress: YomitanImportProgress?
     @Published var lastImportError: Error?
-
+    
     private var currentImporter: YomitanDictionaryImporter?
-
+    
     private init() {}
-
+    
     /// Import a Yomitan dictionary from a ZIP file or single JSON file URL
     @MainActor
     func importDictionary(from fileURL: URL) async {
         guard !isImporting else {
             return
         }
-
+        
         isImporting = true
         importProgress = nil
         lastImportError = nil
-
+        
         do {
             // CRITICAL: Start accessing security-scoped resource
             let shouldStopAccessing = fileURL.startAccessingSecurityScopedResource()
@@ -33,95 +33,93 @@ class DictionaryImportManager: ObservableObject {
                     fileURL.stopAccessingSecurityScopedResource()
                 }
             }
-
+            
             // Verify we can access the file
             guard FileManager.default.fileExists(atPath: fileURL.path) else {
-                throw ImportError.fileNotAccessible(
-                    "Cannot access the selected file. Please try selecting it again.")
+                throw ImportError.fileNotAccessible("Cannot access the selected file. Please try selecting it again.")
             }
-
+            
             // Read file data
             let fileData = try Data(contentsOf: fileURL)
-
+            
             // Detect file type and handle accordingly
             let fileExtension = fileURL.pathExtension.lowercased()
             let finalData: Data
-
+            
             if fileExtension == "json" {
                 // Convert single JSON file to Yomitan ZIP format
                 print("📝 Detected JSON file, converting to Yomitan format...")
-                finalData = try convertSingleJSONToYomitanZip(
-                    jsonData: fileData, filename: fileURL.lastPathComponent)
+                finalData = try convertSingleJSONToYomitanZip(jsonData: fileData, filename: fileURL.lastPathComponent)
             } else if fileExtension == "zip" {
                 // Check if this ZIP contains a single JSON that needs conversion
                 print("📦 Detected ZIP file, checking contents...")
-                finalData = try handleZipFile(
-                    zipData: fileData, filename: fileURL.lastPathComponent)
+                finalData = try handleZipFile(zipData: fileData, filename: fileURL.lastPathComponent)
             } else {
                 // Assume it's a ZIP file
                 finalData = fileData
             }
-
+            
             // Create importer with progress callback
             currentImporter = YomitanDictionaryImporter { [weak self] progress in
                 DispatchQueue.main.async {
                     self?.importProgress = progress
                 }
             }
-
+            
             // Generate unique database filename
             let databaseURL = try generateDatabaseURL()
-
+            
             // Import dictionary
             let index = try await currentImporter!.importDictionary(
                 from: finalData,
                 to: databaseURL
             )
-
+            
             // Add to DictionaryManager
             try registerImportedDictionary(at: databaseURL, index: index)
-
+            
+            
         } catch {
             lastImportError = error
         }
-
+        
         isImporting = false
         currentImporter = nil
     }
-
+    
     /// Cancel current import operation
     func cancelImport() {
         currentImporter?.cancel()
     }
-
+    
     /// Force reload of imported dictionaries (for debugging)
     func reloadImportedDictionaries() {
         DictionaryManager.shared.reloadImportedDictionaries()
     }
-
+    
     /// Clear all registry entries - useful for testing
     func clearRegistry() {
         UserDefaults.standard.removeObject(forKey: "ImportedDictionaries")
     }
-
+    
     /// Get list of imported dictionaries
     func getImportedDictionaries() -> [ImportedDictionaryInfo] {
         return loadRegistry()
     }
-
+    
     /// Delete an imported dictionary
     @MainActor
     func deleteImportedDictionary(_ info: ImportedDictionaryInfo) throws {
-
+        
         // First, notify DictionaryManager to release any database connections
         DictionaryManager.shared.reloadImportedDictionaries()
-
+        
         // Small delay to ensure connections are closed
         Thread.sleep(forTimeInterval: 0.1)
-
+        
         // Get current database URL (this handles path resolution properly)
         let databaseURL = info.databaseURL
-
+        
         // Remove database file
         if FileManager.default.fileExists(atPath: databaseURL.path) {
             do {
@@ -131,16 +129,16 @@ class DictionaryImportManager: ObservableObject {
             }
         } else {
         }
-
+        
         // Remove from registry
         var registry = loadRegistry()
         let originalCount = registry.count
         registry.removeAll { $0.id == info.id }
-
+        
         if registry.count < originalCount {
         } else {
         }
-
+        
         // Save updated registry
         do {
             let data = try JSONEncoder().encode(registry)
@@ -148,88 +146,83 @@ class DictionaryImportManager: ObservableObject {
         } catch {
             throw error
         }
-
+        
         // Final cleanup - reload dictionaries
         DictionaryManager.shared.reloadImportedDictionaries()
-
+        
     }
-
+    
     // MARK: - Private Methods
-
+    
     /// Handle ZIP file - check if it needs conversion or can be used as-is
     private func handleZipFile(zipData: Data, filename: String) throws -> Data {
         do {
             // Try to extract the ZIP to see what's inside
             let extractedFiles = try SimpleZipExtractor.extractFiles(from: zipData)
             print("📂 ZIP contents: \(extractedFiles.keys.sorted())")
-
+            
             // Check if it already has index.json (standard Yomitan format)
             if extractedFiles.keys.contains("index.json") {
                 print("✅ Standard Yomitan ZIP detected with index.json")
                 return zipData
             }
-
+            
             // Check if it contains a single JSON file that needs conversion
             let jsonFiles = extractedFiles.filter { $0.key.hasSuffix(".json") }
             if jsonFiles.count == 1,
-                let (jsonFilename, jsonData) = jsonFiles.first,
-                let jsonArray = try? JSONSerialization.jsonObject(with: jsonData)
-                    as? [[String: Any]],
-                let firstEntry = jsonArray.first,
-                firstEntry.keys.contains("term") && firstEntry.keys.contains("definition")
-            {
-
+               let (jsonFilename, jsonData) = jsonFiles.first,
+               let jsonArray = try? JSONSerialization.jsonObject(with: jsonData) as? [[String: Any]],
+               let firstEntry = jsonArray.first,
+               firstEntry.keys.contains("term") && firstEntry.keys.contains("definition") {
+                
                 print("🔄 Found single JSON dictionary in ZIP, converting...")
                 return try convertSingleJSONToYomitanZip(entries: jsonArray, filename: jsonFilename)
             }
-
+            
             // If none of the above, return as-is and let the importer handle errors
             print("⚠️ ZIP doesn't contain standard Yomitan format or convertible JSON")
             return zipData
-
+            
         } catch {
             print("❌ Error extracting ZIP: \(error)")
             // If extraction fails, return as-is and let the importer handle it
             return zipData
         }
     }
-
+    
     /// Convert a single JSON dictionary file to Yomitan ZIP format
     private func convertSingleJSONToYomitanZip(jsonData: Data, filename: String) throws -> Data {
         // Parse the JSON to determine structure
         guard let jsonArray = try? JSONSerialization.jsonObject(with: jsonData) as? [[String: Any]],
-            let firstEntry = jsonArray.first
-        else {
+              let firstEntry = jsonArray.first else {
             throw ImportError.invalidJSONFormat("Unable to parse JSON as dictionary array")
         }
-
+        
         // Detect if this is a single JSON dictionary (has term, definition fields)
         if firstEntry.keys.contains("term") && firstEntry.keys.contains("definition") {
             return try convertSingleJSONToYomitanZip(entries: jsonArray, filename: filename)
         }
-
+        
         // If it's already in Yomitan format, wrap it in a ZIP
-        throw ImportError.unsupportedJSONFormat(
-            "JSON format not recognized. Only single JSON dictionaries with term/definition format are currently supported."
-        )
+        throw ImportError.unsupportedJSONFormat("JSON format not recognized. Only single JSON dictionaries with term/definition format are currently supported.")
     }
-
+    
     /// Check if a term contains only hiragana characters
     private func isHiraganaOnly(_ text: String) -> Bool {
         guard !text.isEmpty else { return false }
-
+        
         let hiraganaRange = 0x3040...0x309F
-
+        
         for scalar in text.unicodeScalars {
             let value = Int(scalar.value)
             if !hiraganaRange.contains(value) {
                 return false
             }
         }
-
+        
         return true
     }
-
+    
     /// Extract kanji from definition HTML (e.g., "[愛]" or "[会い|逢い]")
     private func extractKanjiFromDefinition(_ definition: String) -> [String] {
         // Look for pattern like <b>term</b>[kanji] or <b>term</b>[kanji1|kanji2]
@@ -237,55 +230,50 @@ class DictionaryImportManager: ObservableObject {
         guard let regex = try? NSRegularExpression(pattern: pattern, options: []) else {
             return []
         }
-
+        
         let range = NSRange(definition.startIndex..., in: definition)
         guard let match = regex.firstMatch(in: definition, options: [], range: range),
-            match.numberOfRanges > 1
-        else {
+              match.numberOfRanges > 1 else {
             return []
         }
-
+        
         let kanjiRange = Range(match.range(at: 1), in: definition)!
         let kanjiString = String(definition[kanjiRange])
-
+        
         // Split on "|" for multiple variants and clean up
         return kanjiString.components(separatedBy: "|")
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .compactMap { cleanKanjiExpression($0) }
             .filter { !$0.isEmpty }
     }
-
+    
     /// Clean kanji expression by removing Korean annotations and other noise
     private func cleanKanjiExpression(_ expression: String) -> String? {
-        // Remove Korean annotations like "(인명용 한자)"
-        let cleanedExpression =
-            expression
+        // Remove Korean annotations like "(인명용 한자)" 
+        let cleanedExpression = expression
             .replacingOccurrences(of: #"\([^)]*한자[^)]*\)"#, with: "", options: .regularExpression)
             .trimmingCharacters(in: .whitespacesAndNewlines)
-
+        
         // Return nil if the cleaned expression is empty or has no kanji/hiragana/katakana
         guard !cleanedExpression.isEmpty,
-            cleanedExpression.unicodeScalars.contains(where: { scalar in
-                let value = Int(scalar.value)
-                return (0x3040...0x309F).contains(value)  // Hiragana
-                    || (0x30A0...0x30FF).contains(value)  // Katakana
-                    || (0x4E00...0x9FFF).contains(value)  // Kanji
-            })
-        else {
+              cleanedExpression.unicodeScalars.contains(where: { scalar in
+                  let value = Int(scalar.value)
+                  return (0x3040...0x309F).contains(value) ||  // Hiragana
+                         (0x30A0...0x30FF).contains(value) ||  // Katakana
+                         (0x4E00...0x9FFF).contains(value)     // Kanji
+              }) else {
             return nil
         }
-
+        
         return cleanedExpression
     }
-
+    
     /// Convert single JSON dictionary format to Yomitan ZIP
-    private func convertSingleJSONToYomitanZip(entries: [[String: Any]], filename: String) throws
-        -> Data
-    {
+    private func convertSingleJSONToYomitanZip(entries: [[String: Any]], filename: String) throws -> Data {
         // Extract dictionary name from filename
         let dictionaryName = filename.replacingOccurrences(of: ".json", with: "")
         print("🏷️ Converting \(entries.count) entries for dictionary: \(dictionaryName)")
-
+        
         // Create index.json
         let index: [String: Any] = [
             "title": dictionaryName,
@@ -295,50 +283,48 @@ class DictionaryImportManager: ObservableObject {
             "description": "Imported from \(filename)",
             "author": "Unknown",
             "url": "",
-            "tags": [:] as [String: Any],
+            "tags": [:] as [String: Any]
         ]
-
+        
         print("📋 Created index with title: \(dictionaryName)")
-
+        
         // Convert entries to Yomitan term format
         var yomitanTerms: [[Any]] = []
-
+        
         for entry in entries {
             guard let term = entry["term"] as? String,
-                let definition = entry["definition"] as? String
-            else {
+                  let definition = entry["definition"] as? String else {
                 continue
             }
-
+            
             let altterm = entry["altterm"] as? String ?? ""
             let pos = entry["pos"] as? String ?? ""
             let pronunciation = entry["pronunciation"] as? String ?? ""
-
+            
             // Create reading (use altterm if available, otherwise same as term)
             let reading = !altterm.isEmpty ? altterm : term
-
+            
             // Parse definitions from HTML format
-            let cleanDefinition =
-                definition
+            let cleanDefinition = definition
                 .replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression)
                 .trimmingCharacters(in: .whitespacesAndNewlines)
-
+            
             // Check if term is hiragana-only and try to extract kanji from definition
             if isHiraganaOnly(term) && altterm.isEmpty {
                 let extractedKanji = extractKanjiFromDefinition(definition)
-
+                
                 if !extractedKanji.isEmpty {
                     // Create separate entries for each kanji variant
                     for kanjiExpression in extractedKanji {
                         let yomitanTerm: [Any] = [
-                            kanjiExpression,  // expression (kanji)
-                            term,  // reading (original hiragana)
+                            kanjiExpression,         // expression (kanji)
+                            term,                    // reading (original hiragana)
                             pos.isEmpty ? "" : pos,  // definitionTags
-                            "",  // rules
-                            0,  // score
-                            [cleanDefinition],  // glossary (array of definitions)
-                            0,  // sequence
-                            "",  // termTags
+                            "",                      // rules
+                            0,                       // score
+                            [cleanDefinition],       // glossary (array of definitions)
+                            0,                       // sequence
+                            ""                       // termTags
                         ]
                         yomitanTerms.append(yomitanTerm)
                     }
@@ -346,79 +332,79 @@ class DictionaryImportManager: ObservableObject {
                 } else {
                     // No kanji found, create entry with original hiragana term
                     let yomitanTerm: [Any] = [
-                        term,  // expression
-                        reading,  // reading
+                        term,                    // expression
+                        reading,                 // reading
                         pos.isEmpty ? "" : pos,  // definitionTags
-                        "",  // rules
-                        0,  // score
-                        [cleanDefinition],  // glossary (array of definitions)
-                        0,  // sequence
-                        "",  // termTags
+                        "",                      // rules
+                        0,                       // score
+                        [cleanDefinition],       // glossary (array of definitions)
+                        0,                       // sequence
+                        ""                       // termTags
                     ]
                     yomitanTerms.append(yomitanTerm)
                 }
             } else {
                 // Term is not hiragana-only or has altterm, use standard processing
                 let yomitanTerm: [Any] = [
-                    term,  // expression
-                    reading,  // reading
+                    term,                    // expression
+                    reading,                 // reading
                     pos.isEmpty ? "" : pos,  // definitionTags
-                    "",  // rules
-                    0,  // score
-                    [cleanDefinition],  // glossary (array of definitions)
-                    0,  // sequence
-                    "",  // termTags
+                    "",                      // rules
+                    0,                       // score
+                    [cleanDefinition],       // glossary (array of definitions)
+                    0,                       // sequence
+                    ""                       // termTags
                 ]
                 yomitanTerms.append(yomitanTerm)
             }
         }
-
+        
         print("✅ Converted \(yomitanTerms.count) terms successfully")
-
+        
         // Create ZIP archive
         let zipData = try createYomitanZip(index: index, terms: yomitanTerms)
         print("📦 Created ZIP archive with \(zipData.count) bytes")
-
+        
         return zipData
     }
-
+    
     /// Create a Yomitan-compatible ZIP archive
     private func createYomitanZip(index: [String: Any], terms: [[Any]]) throws -> Data {
         // Convert to JSON data
         let indexData = try JSONSerialization.data(withJSONObject: index, options: [])
         let termsData = try JSONSerialization.data(withJSONObject: terms, options: [])
-
+        
         print("📄 Created index.json: \(indexData.count) bytes")
         print("📄 Created term_bank_1.json: \(termsData.count) bytes")
-
+        
         // Create a simple ZIP using a basic implementation
         let zipData = try createSimpleZip(files: [
             "index.json": indexData,
-            "term_bank_1.json": termsData,
+            "term_bank_1.json": termsData
         ])
-
+        
         print("🗂️ Final ZIP contains files: index.json, term_bank_1.json")
         return zipData
     }
-
+    
     /// Create a simple ZIP archive with the given files
     private func createSimpleZip(files: [String: Data]) throws -> Data {
         // Create a minimal ZIP file structure manually
         // This creates a basic ZIP file compatible with the existing extractor
-
+        
         var zipData = Data()
         var centralDirectory = Data()
         var localHeaderOffset: UInt32 = 0
-
+        
         for (filename, fileData) in files {
             // Local file header
             let localHeader = createLocalFileHeader(filename: filename, fileData: fileData)
             let localHeaderSize = UInt32(localHeader.count)
-
+            
             // Add local header and file data to ZIP
             zipData.append(localHeader)
             zipData.append(fileData)
-
+            
             // Create central directory entry
             let centralDirEntry = createCentralDirectoryEntry(
                 filename: filename,
@@ -426,14 +412,14 @@ class DictionaryImportManager: ObservableObject {
                 localHeaderOffset: localHeaderOffset
             )
             centralDirectory.append(centralDirEntry)
-
+            
             localHeaderOffset += localHeaderSize + UInt32(fileData.count)
         }
-
+        
         // Add central directory to ZIP
         let centralDirOffset = UInt32(zipData.count)
         zipData.append(centralDirectory)
-
+        
         // Add end of central directory record
         let endRecord = createEndOfCentralDirectoryRecord(
             entryCount: UInt16(files.count),
@@ -441,75 +427,71 @@ class DictionaryImportManager: ObservableObject {
             centralDirOffset: centralDirOffset
         )
         zipData.append(endRecord)
-
+        
         return zipData
     }
-
+    
     private func createLocalFileHeader(filename: String, fileData: Data) -> Data {
         var header = Data()
         let filenameData = filename.data(using: .utf8)!
-
-        header.append(UInt32(0x0403_4b50).littleEndianData)  // Local file header signature
-        header.append(UInt16(20).littleEndianData)  // Version needed to extract
-        header.append(UInt16(0).littleEndianData)  // General purpose bit flag
-        header.append(UInt16(0).littleEndianData)  // Compression method (no compression)
-        header.append(UInt16(0).littleEndianData)  // Last mod file time
-        header.append(UInt16(0).littleEndianData)  // Last mod file date
-        header.append(UInt32(0).littleEndianData)  // CRC-32 (we'll skip for simplicity)
-        header.append(UInt32(fileData.count).littleEndianData)  // Compressed size
-        header.append(UInt32(fileData.count).littleEndianData)  // Uncompressed size
-        header.append(UInt16(filenameData.count).littleEndianData)  // Filename length
-        header.append(UInt16(0).littleEndianData)  // Extra field length
-        header.append(filenameData)  // Filename
-
+        
+        header.append(UInt32(0x04034b50).littleEndianData) // Local file header signature
+        header.append(UInt16(20).littleEndianData)          // Version needed to extract
+        header.append(UInt16(0).littleEndianData)           // General purpose bit flag
+        header.append(UInt16(0).littleEndianData)           // Compression method (no compression)
+        header.append(UInt16(0).littleEndianData)           // Last mod file time
+        header.append(UInt16(0).littleEndianData)           // Last mod file date
+        header.append(UInt32(0).littleEndianData)           // CRC-32 (we'll skip for simplicity)
+        header.append(UInt32(fileData.count).littleEndianData) // Compressed size
+        header.append(UInt32(fileData.count).littleEndianData) // Uncompressed size
+        header.append(UInt16(filenameData.count).littleEndianData) // Filename length
+        header.append(UInt16(0).littleEndianData)           // Extra field length
+        header.append(filenameData)                         // Filename
+        
         return header
     }
-
-    private func createCentralDirectoryEntry(
-        filename: String, fileData: Data, localHeaderOffset: UInt32
-    ) -> Data {
+    
+    private func createCentralDirectoryEntry(filename: String, fileData: Data, localHeaderOffset: UInt32) -> Data {
         var entry = Data()
         let filenameData = filename.data(using: .utf8)!
-
-        entry.append(UInt32(0x0201_4b50).littleEndianData)  // Central directory signature
-        entry.append(UInt16(20).littleEndianData)  // Version made by
-        entry.append(UInt16(20).littleEndianData)  // Version needed to extract
-        entry.append(UInt16(0).littleEndianData)  // General purpose bit flag
-        entry.append(UInt16(0).littleEndianData)  // Compression method
-        entry.append(UInt16(0).littleEndianData)  // Last mod file time
-        entry.append(UInt16(0).littleEndianData)  // Last mod file date
-        entry.append(UInt32(0).littleEndianData)  // CRC-32
-        entry.append(UInt32(fileData.count).littleEndianData)  // Compressed size
-        entry.append(UInt32(fileData.count).littleEndianData)  // Uncompressed size
-        entry.append(UInt16(filenameData.count).littleEndianData)  // Filename length
-        entry.append(UInt16(0).littleEndianData)  // Extra field length
-        entry.append(UInt16(0).littleEndianData)  // File comment length
-        entry.append(UInt16(0).littleEndianData)  // Disk number start
-        entry.append(UInt16(0).littleEndianData)  // Internal file attributes
-        entry.append(UInt32(0).littleEndianData)  // External file attributes
-        entry.append(localHeaderOffset.littleEndianData)  // Local header offset
-        entry.append(filenameData)  // Filename
-
+        
+        entry.append(UInt32(0x02014b50).littleEndianData)   // Central directory signature
+        entry.append(UInt16(20).littleEndianData)           // Version made by
+        entry.append(UInt16(20).littleEndianData)           // Version needed to extract
+        entry.append(UInt16(0).littleEndianData)            // General purpose bit flag
+        entry.append(UInt16(0).littleEndianData)            // Compression method
+        entry.append(UInt16(0).littleEndianData)            // Last mod file time
+        entry.append(UInt16(0).littleEndianData)            // Last mod file date
+        entry.append(UInt32(0).littleEndianData)            // CRC-32
+        entry.append(UInt32(fileData.count).littleEndianData) // Compressed size
+        entry.append(UInt32(fileData.count).littleEndianData) // Uncompressed size
+        entry.append(UInt16(filenameData.count).littleEndianData) // Filename length
+        entry.append(UInt16(0).littleEndianData)            // Extra field length
+        entry.append(UInt16(0).littleEndianData)            // File comment length
+        entry.append(UInt16(0).littleEndianData)            // Disk number start
+        entry.append(UInt16(0).littleEndianData)            // Internal file attributes
+        entry.append(UInt32(0).littleEndianData)            // External file attributes
+        entry.append(localHeaderOffset.littleEndianData)    // Local header offset
+        entry.append(filenameData)                          // Filename
+        
         return entry
     }
-
-    private func createEndOfCentralDirectoryRecord(
-        entryCount: UInt16, centralDirSize: UInt32, centralDirOffset: UInt32
-    ) -> Data {
+    
+    private func createEndOfCentralDirectoryRecord(entryCount: UInt16, centralDirSize: UInt32, centralDirOffset: UInt32) -> Data {
         var record = Data()
-
-        record.append(UInt32(0x0605_4b50).littleEndianData)  // End of central dir signature
-        record.append(UInt16(0).littleEndianData)  // Number of this disk
-        record.append(UInt16(0).littleEndianData)  // Disk where central directory starts
-        record.append(entryCount.littleEndianData)  // Number of central directory records on this disk
-        record.append(entryCount.littleEndianData)  // Total number of central directory records
-        record.append(centralDirSize.littleEndianData)  // Size of central directory
-        record.append(centralDirOffset.littleEndianData)  // Offset of start of central directory
-        record.append(UInt16(0).littleEndianData)  // ZIP file comment length
-
+        
+        record.append(UInt32(0x06054b50).littleEndianData)  // End of central dir signature
+        record.append(UInt16(0).littleEndianData)           // Number of this disk
+        record.append(UInt16(0).littleEndianData)           // Disk where central directory starts
+        record.append(entryCount.littleEndianData)          // Number of central directory records on this disk
+        record.append(entryCount.littleEndianData)          // Total number of central directory records
+        record.append(centralDirSize.littleEndianData)      // Size of central directory
+        record.append(centralDirOffset.littleEndianData)    // Offset of start of central directory
+        record.append(UInt16(0).littleEndianData)           // ZIP file comment length
+        
         return record
     }
-
+    
     private func generateDatabaseURL() throws -> URL {
         let documentsURL = try FileManager.default.url(
             for: .documentDirectory,
@@ -517,23 +499,23 @@ class DictionaryImportManager: ObservableObject {
             appropriateFor: nil,
             create: true
         )
-
+        
         let dictionariesURL = documentsURL.appendingPathComponent("ImportedDictionaries")
-
+        
         // Create directory if it doesn't exist
         try FileManager.default.createDirectory(
             at: dictionariesURL,
             withIntermediateDirectories: true,
             attributes: nil
         )
-
+        
         // Generate unique filename
         let timestamp = Int(Date().timeIntervalSince1970)
         let filename = "imported_dictionary_\(timestamp).db"
-
+        
         return dictionariesURL.appendingPathComponent(filename)
     }
-
+    
     private func registerImportedDictionary(at databaseURL: URL, index: YomitanIndex) throws {
         // Store dictionary metadata for future reference - only store filename
         let filename = databaseURL.lastPathComponent
@@ -546,30 +528,29 @@ class DictionaryImportManager: ObservableObject {
             databaseFilename: filename,
             importDate: Date()
         )
-
+        
         // Save to registry
         saveToRegistry(info)
-
+        
         // Notify DictionaryManager about new dictionary
         DictionaryManager.shared.reloadImportedDictionaries()
     }
-
+    
     private func saveToRegistry(_ info: ImportedDictionaryInfo) {
         var registry = loadRegistry()
         registry.append(info)
-
+        
         if let data = try? JSONEncoder().encode(registry) {
             UserDefaults.standard.set(data, forKey: "ImportedDictionaries")
         }
     }
-
+    
     private func loadRegistry() -> [ImportedDictionaryInfo] {
         guard let data = UserDefaults.standard.data(forKey: "ImportedDictionaries"),
-            let registry = try? JSONDecoder().decode([ImportedDictionaryInfo].self, from: data)
-        else {
+              let registry = try? JSONDecoder().decode([ImportedDictionaryInfo].self, from: data) else {
             return []
         }
-
+        
         // Clean up registry: remove entries for files that no longer exist
         let validEntries = registry.filter { info in
             let fileExists = FileManager.default.fileExists(atPath: info.databaseURL.path)
@@ -577,14 +558,14 @@ class DictionaryImportManager: ObservableObject {
             }
             return fileExists
         }
-
+        
         // Save cleaned registry if it changed
         if validEntries.count != registry.count {
             if let data = try? JSONEncoder().encode(validEntries) {
                 UserDefaults.standard.set(data, forKey: "ImportedDictionaries")
             }
         }
-
+        
         return validEntries
     }
 }
@@ -595,7 +576,7 @@ enum ImportError: Error, LocalizedError {
     case invalidJSONFormat(String)
     case unsupportedJSONFormat(String)
     case zipCreationFailed(String)
-
+    
     var errorDescription: String? {
         switch self {
         case .fileNotAccessible(let message):
@@ -620,14 +601,11 @@ struct ImportedDictionaryInfo: Codable, Identifiable {
     let description: String?
     let databaseFilename: String  // Store just the filename, not full path
     let importDate: Date
-
+    
     // Support for legacy entries that stored full URLs
     private let legacyDatabaseURL: URL?
-
-    init(
-        title: String, revision: String, version: Int, author: String?, description: String?,
-        databaseFilename: String, importDate: Date
-    ) {
+    
+    init(title: String, revision: String, version: Int, author: String?, description: String?, databaseFilename: String, importDate: Date) {
         self.id = UUID()
         self.title = title
         self.revision = revision
@@ -638,11 +616,11 @@ struct ImportedDictionaryInfo: Codable, Identifiable {
         self.importDate = importDate
         self.legacyDatabaseURL = nil
     }
-
+    
     // Custom decoder to handle legacy format
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-
+        
         self.id = (try? container.decode(UUID.self, forKey: .id)) ?? UUID()
         self.title = try container.decode(String.self, forKey: .title)
         self.revision = try container.decode(String.self, forKey: .revision)
@@ -650,7 +628,7 @@ struct ImportedDictionaryInfo: Codable, Identifiable {
         self.author = try? container.decode(String.self, forKey: .author)
         self.description = try? container.decode(String.self, forKey: .description)
         self.importDate = try container.decode(Date.self, forKey: .importDate)
-
+        
         // Handle legacy databaseURL vs new databaseFilename
         if let filename = try? container.decode(String.self, forKey: .databaseFilename) {
             // New format
@@ -661,39 +639,35 @@ struct ImportedDictionaryInfo: Codable, Identifiable {
             self.databaseFilename = url.lastPathComponent
             self.legacyDatabaseURL = url
         } else {
-            throw DecodingError.keyNotFound(
-                CodingKeys.databaseFilename,
-                DecodingError.Context(
-                    codingPath: decoder.codingPath,
-                    debugDescription: "Missing databaseFilename or legacyDatabaseURL"))
+            throw DecodingError.keyNotFound(CodingKeys.databaseFilename, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Missing databaseFilename or legacyDatabaseURL"))
         }
     }
-
+    
     private enum CodingKeys: String, CodingKey {
         case id, title, revision, version, author, description, databaseFilename, importDate
         case legacyDatabaseURL = "databaseURL"
     }
-
+    
     var displayName: String {
         return title
     }
-
+    
     var detailText: String {
         var details: [String] = []
-
+        
         if let author = author, !author.isEmpty {
             details.append("by \(author)")
         }
-
+        
         details.append("v\(revision)")
-
+        
         let formatter = DateFormatter()
         formatter.dateStyle = .medium
         details.append("imported \(formatter.string(from: importDate))")
-
+        
         return details.joined(separator: " • ")
     }
-
+    
     /// Get the full database URL using current Documents directory
     var databaseURL: URL {
         do {
@@ -703,8 +677,7 @@ struct ImportedDictionaryInfo: Codable, Identifiable {
                 appropriateFor: nil,
                 create: false
             )
-            return
-                documentsURL
+            return documentsURL
                 .appendingPathComponent("ImportedDictionaries")
                 .appendingPathComponent(databaseFilename)
         } catch {

--- a/Shiori Reader/Features/DictionaryImport/DictionaryImportManager.swift
+++ b/Shiori Reader/Features/DictionaryImport/DictionaryImportManager.swift
@@ -3,28 +3,28 @@ import GRDB
 
 /// Manages the import of Yomitan dictionaries and integrates with the existing DictionaryManager
 class DictionaryImportManager: ObservableObject {
-    
+
     static let shared = DictionaryImportManager()
-    
+
     @Published var isImporting = false
     @Published var importProgress: YomitanImportProgress?
     @Published var lastImportError: Error?
-    
+
     private var currentImporter: YomitanDictionaryImporter?
-    
+
     private init() {}
-    
+
     /// Import a Yomitan dictionary from a ZIP file or single JSON file URL
     @MainActor
     func importDictionary(from fileURL: URL) async {
         guard !isImporting else {
             return
         }
-        
+
         isImporting = true
         importProgress = nil
         lastImportError = nil
-        
+
         do {
             // CRITICAL: Start accessing security-scoped resource
             let shouldStopAccessing = fileURL.startAccessingSecurityScopedResource()
@@ -33,93 +33,95 @@ class DictionaryImportManager: ObservableObject {
                     fileURL.stopAccessingSecurityScopedResource()
                 }
             }
-            
+
             // Verify we can access the file
             guard FileManager.default.fileExists(atPath: fileURL.path) else {
-                throw ImportError.fileNotAccessible("Cannot access the selected file. Please try selecting it again.")
+                throw ImportError.fileNotAccessible(
+                    "Cannot access the selected file. Please try selecting it again.")
             }
-            
+
             // Read file data
             let fileData = try Data(contentsOf: fileURL)
-            
+
             // Detect file type and handle accordingly
             let fileExtension = fileURL.pathExtension.lowercased()
             let finalData: Data
-            
+
             if fileExtension == "json" {
                 // Convert single JSON file to Yomitan ZIP format
                 print("📝 Detected JSON file, converting to Yomitan format...")
-                finalData = try convertSingleJSONToYomitanZip(jsonData: fileData, filename: fileURL.lastPathComponent)
+                finalData = try convertSingleJSONToYomitanZip(
+                    jsonData: fileData, filename: fileURL.lastPathComponent)
             } else if fileExtension == "zip" {
                 // Check if this ZIP contains a single JSON that needs conversion
                 print("📦 Detected ZIP file, checking contents...")
-                finalData = try handleZipFile(zipData: fileData, filename: fileURL.lastPathComponent)
+                finalData = try handleZipFile(
+                    zipData: fileData, filename: fileURL.lastPathComponent)
             } else {
                 // Assume it's a ZIP file
                 finalData = fileData
             }
-            
+
             // Create importer with progress callback
             currentImporter = YomitanDictionaryImporter { [weak self] progress in
                 DispatchQueue.main.async {
                     self?.importProgress = progress
                 }
             }
-            
+
             // Generate unique database filename
             let databaseURL = try generateDatabaseURL()
-            
+
             // Import dictionary
             let index = try await currentImporter!.importDictionary(
                 from: finalData,
                 to: databaseURL
             )
-            
+
             // Add to DictionaryManager
             try registerImportedDictionary(at: databaseURL, index: index)
-            
-            
+
         } catch {
             lastImportError = error
         }
-        
+
         isImporting = false
         currentImporter = nil
     }
-    
+
     /// Cancel current import operation
     func cancelImport() {
         currentImporter?.cancel()
     }
-    
+
     /// Force reload of imported dictionaries (for debugging)
     func reloadImportedDictionaries() {
         DictionaryManager.shared.reloadImportedDictionaries()
     }
-    
+
     /// Clear all registry entries - useful for testing
     func clearRegistry() {
         UserDefaults.standard.removeObject(forKey: "ImportedDictionaries")
     }
-    
+
     /// Get list of imported dictionaries
     func getImportedDictionaries() -> [ImportedDictionaryInfo] {
         return loadRegistry()
     }
-    
+
     /// Delete an imported dictionary
     @MainActor
     func deleteImportedDictionary(_ info: ImportedDictionaryInfo) throws {
-        
+
         // First, notify DictionaryManager to release any database connections
         DictionaryManager.shared.reloadImportedDictionaries()
-        
+
         // Small delay to ensure connections are closed
         Thread.sleep(forTimeInterval: 0.1)
-        
+
         // Get current database URL (this handles path resolution properly)
         let databaseURL = info.databaseURL
-        
+
         // Remove database file
         if FileManager.default.fileExists(atPath: databaseURL.path) {
             do {
@@ -129,16 +131,16 @@ class DictionaryImportManager: ObservableObject {
             }
         } else {
         }
-        
+
         // Remove from registry
         var registry = loadRegistry()
         let originalCount = registry.count
         registry.removeAll { $0.id == info.id }
-        
+
         if registry.count < originalCount {
         } else {
         }
-        
+
         // Save updated registry
         do {
             let data = try JSONEncoder().encode(registry)
@@ -146,83 +148,88 @@ class DictionaryImportManager: ObservableObject {
         } catch {
             throw error
         }
-        
+
         // Final cleanup - reload dictionaries
         DictionaryManager.shared.reloadImportedDictionaries()
-        
+
     }
-    
+
     // MARK: - Private Methods
-    
+
     /// Handle ZIP file - check if it needs conversion or can be used as-is
     private func handleZipFile(zipData: Data, filename: String) throws -> Data {
         do {
             // Try to extract the ZIP to see what's inside
             let extractedFiles = try SimpleZipExtractor.extractFiles(from: zipData)
             print("📂 ZIP contents: \(extractedFiles.keys.sorted())")
-            
+
             // Check if it already has index.json (standard Yomitan format)
             if extractedFiles.keys.contains("index.json") {
                 print("✅ Standard Yomitan ZIP detected with index.json")
                 return zipData
             }
-            
+
             // Check if it contains a single JSON file that needs conversion
             let jsonFiles = extractedFiles.filter { $0.key.hasSuffix(".json") }
             if jsonFiles.count == 1,
-               let (jsonFilename, jsonData) = jsonFiles.first,
-               let jsonArray = try? JSONSerialization.jsonObject(with: jsonData) as? [[String: Any]],
-               let firstEntry = jsonArray.first,
-               firstEntry.keys.contains("term") && firstEntry.keys.contains("definition") {
-                
+                let (jsonFilename, jsonData) = jsonFiles.first,
+                let jsonArray = try? JSONSerialization.jsonObject(with: jsonData)
+                    as? [[String: Any]],
+                let firstEntry = jsonArray.first,
+                firstEntry.keys.contains("term") && firstEntry.keys.contains("definition")
+            {
+
                 print("🔄 Found single JSON dictionary in ZIP, converting...")
                 return try convertSingleJSONToYomitanZip(entries: jsonArray, filename: jsonFilename)
             }
-            
+
             // If none of the above, return as-is and let the importer handle errors
             print("⚠️ ZIP doesn't contain standard Yomitan format or convertible JSON")
             return zipData
-            
+
         } catch {
             print("❌ Error extracting ZIP: \(error)")
             // If extraction fails, return as-is and let the importer handle it
             return zipData
         }
     }
-    
+
     /// Convert a single JSON dictionary file to Yomitan ZIP format
     private func convertSingleJSONToYomitanZip(jsonData: Data, filename: String) throws -> Data {
         // Parse the JSON to determine structure
         guard let jsonArray = try? JSONSerialization.jsonObject(with: jsonData) as? [[String: Any]],
-              let firstEntry = jsonArray.first else {
+            let firstEntry = jsonArray.first
+        else {
             throw ImportError.invalidJSONFormat("Unable to parse JSON as dictionary array")
         }
-        
+
         // Detect if this is a single JSON dictionary (has term, definition fields)
         if firstEntry.keys.contains("term") && firstEntry.keys.contains("definition") {
             return try convertSingleJSONToYomitanZip(entries: jsonArray, filename: filename)
         }
-        
+
         // If it's already in Yomitan format, wrap it in a ZIP
-        throw ImportError.unsupportedJSONFormat("JSON format not recognized. Only single JSON dictionaries with term/definition format are currently supported.")
+        throw ImportError.unsupportedJSONFormat(
+            "JSON format not recognized. Only single JSON dictionaries with term/definition format are currently supported."
+        )
     }
-    
+
     /// Check if a term contains only hiragana characters
     private func isHiraganaOnly(_ text: String) -> Bool {
         guard !text.isEmpty else { return false }
-        
+
         let hiraganaRange = 0x3040...0x309F
-        
+
         for scalar in text.unicodeScalars {
             let value = Int(scalar.value)
             if !hiraganaRange.contains(value) {
                 return false
             }
         }
-        
+
         return true
     }
-    
+
     /// Extract kanji from definition HTML (e.g., "[愛]" or "[会い|逢い]")
     private func extractKanjiFromDefinition(_ definition: String) -> [String] {
         // Look for pattern like <b>term</b>[kanji] or <b>term</b>[kanji1|kanji2]
@@ -230,50 +237,55 @@ class DictionaryImportManager: ObservableObject {
         guard let regex = try? NSRegularExpression(pattern: pattern, options: []) else {
             return []
         }
-        
+
         let range = NSRange(definition.startIndex..., in: definition)
         guard let match = regex.firstMatch(in: definition, options: [], range: range),
-              match.numberOfRanges > 1 else {
+            match.numberOfRanges > 1
+        else {
             return []
         }
-        
+
         let kanjiRange = Range(match.range(at: 1), in: definition)!
         let kanjiString = String(definition[kanjiRange])
-        
+
         // Split on "|" for multiple variants and clean up
         return kanjiString.components(separatedBy: "|")
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .compactMap { cleanKanjiExpression($0) }
             .filter { !$0.isEmpty }
     }
-    
+
     /// Clean kanji expression by removing Korean annotations and other noise
     private func cleanKanjiExpression(_ expression: String) -> String? {
-        // Remove Korean annotations like "(인명용 한자)" 
-        let cleanedExpression = expression
+        // Remove Korean annotations like "(인명용 한자)"
+        let cleanedExpression =
+            expression
             .replacingOccurrences(of: #"\([^)]*한자[^)]*\)"#, with: "", options: .regularExpression)
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        
+
         // Return nil if the cleaned expression is empty or has no kanji/hiragana/katakana
         guard !cleanedExpression.isEmpty,
-              cleanedExpression.unicodeScalars.contains(where: { scalar in
-                  let value = Int(scalar.value)
-                  return (0x3040...0x309F).contains(value) ||  // Hiragana
-                         (0x30A0...0x30FF).contains(value) ||  // Katakana
-                         (0x4E00...0x9FFF).contains(value)     // Kanji
-              }) else {
+            cleanedExpression.unicodeScalars.contains(where: { scalar in
+                let value = Int(scalar.value)
+                return (0x3040...0x309F).contains(value)  // Hiragana
+                    || (0x30A0...0x30FF).contains(value)  // Katakana
+                    || (0x4E00...0x9FFF).contains(value)  // Kanji
+            })
+        else {
             return nil
         }
-        
+
         return cleanedExpression
     }
-    
+
     /// Convert single JSON dictionary format to Yomitan ZIP
-    private func convertSingleJSONToYomitanZip(entries: [[String: Any]], filename: String) throws -> Data {
+    private func convertSingleJSONToYomitanZip(entries: [[String: Any]], filename: String) throws
+        -> Data
+    {
         // Extract dictionary name from filename
         let dictionaryName = filename.replacingOccurrences(of: ".json", with: "")
         print("🏷️ Converting \(entries.count) entries for dictionary: \(dictionaryName)")
-        
+
         // Create index.json
         let index: [String: Any] = [
             "title": dictionaryName,
@@ -283,48 +295,50 @@ class DictionaryImportManager: ObservableObject {
             "description": "Imported from \(filename)",
             "author": "Unknown",
             "url": "",
-            "tags": [:] as [String: Any]
+            "tags": [:] as [String: Any],
         ]
-        
+
         print("📋 Created index with title: \(dictionaryName)")
-        
+
         // Convert entries to Yomitan term format
         var yomitanTerms: [[Any]] = []
-        
+
         for entry in entries {
             guard let term = entry["term"] as? String,
-                  let definition = entry["definition"] as? String else {
+                let definition = entry["definition"] as? String
+            else {
                 continue
             }
-            
+
             let altterm = entry["altterm"] as? String ?? ""
             let pos = entry["pos"] as? String ?? ""
             let pronunciation = entry["pronunciation"] as? String ?? ""
-            
+
             // Create reading (use altterm if available, otherwise same as term)
             let reading = !altterm.isEmpty ? altterm : term
-            
+
             // Parse definitions from HTML format
-            let cleanDefinition = definition
+            let cleanDefinition =
+                definition
                 .replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression)
                 .trimmingCharacters(in: .whitespacesAndNewlines)
-            
+
             // Check if term is hiragana-only and try to extract kanji from definition
             if isHiraganaOnly(term) && altterm.isEmpty {
                 let extractedKanji = extractKanjiFromDefinition(definition)
-                
+
                 if !extractedKanji.isEmpty {
                     // Create separate entries for each kanji variant
                     for kanjiExpression in extractedKanji {
                         let yomitanTerm: [Any] = [
-                            kanjiExpression,         // expression (kanji)
-                            term,                    // reading (original hiragana)
+                            kanjiExpression,  // expression (kanji)
+                            term,  // reading (original hiragana)
                             pos.isEmpty ? "" : pos,  // definitionTags
-                            "",                      // rules
-                            0,                       // score
-                            [cleanDefinition],       // glossary (array of definitions)
-                            0,                       // sequence
-                            ""                       // termTags
+                            "",  // rules
+                            0,  // score
+                            [cleanDefinition],  // glossary (array of definitions)
+                            0,  // sequence
+                            "",  // termTags
                         ]
                         yomitanTerms.append(yomitanTerm)
                     }
@@ -332,79 +346,79 @@ class DictionaryImportManager: ObservableObject {
                 } else {
                     // No kanji found, create entry with original hiragana term
                     let yomitanTerm: [Any] = [
-                        term,                    // expression
-                        reading,                 // reading
+                        term,  // expression
+                        reading,  // reading
                         pos.isEmpty ? "" : pos,  // definitionTags
-                        "",                      // rules
-                        0,                       // score
-                        [cleanDefinition],       // glossary (array of definitions)
-                        0,                       // sequence
-                        ""                       // termTags
+                        "",  // rules
+                        0,  // score
+                        [cleanDefinition],  // glossary (array of definitions)
+                        0,  // sequence
+                        "",  // termTags
                     ]
                     yomitanTerms.append(yomitanTerm)
                 }
             } else {
                 // Term is not hiragana-only or has altterm, use standard processing
                 let yomitanTerm: [Any] = [
-                    term,                    // expression
-                    reading,                 // reading
+                    term,  // expression
+                    reading,  // reading
                     pos.isEmpty ? "" : pos,  // definitionTags
-                    "",                      // rules
-                    0,                       // score
-                    [cleanDefinition],       // glossary (array of definitions)
-                    0,                       // sequence
-                    ""                       // termTags
+                    "",  // rules
+                    0,  // score
+                    [cleanDefinition],  // glossary (array of definitions)
+                    0,  // sequence
+                    "",  // termTags
                 ]
                 yomitanTerms.append(yomitanTerm)
             }
         }
-        
+
         print("✅ Converted \(yomitanTerms.count) terms successfully")
-        
+
         // Create ZIP archive
         let zipData = try createYomitanZip(index: index, terms: yomitanTerms)
         print("📦 Created ZIP archive with \(zipData.count) bytes")
-        
+
         return zipData
     }
-    
+
     /// Create a Yomitan-compatible ZIP archive
     private func createYomitanZip(index: [String: Any], terms: [[Any]]) throws -> Data {
         // Convert to JSON data
         let indexData = try JSONSerialization.data(withJSONObject: index, options: [])
         let termsData = try JSONSerialization.data(withJSONObject: terms, options: [])
-        
+
         print("📄 Created index.json: \(indexData.count) bytes")
         print("📄 Created term_bank_1.json: \(termsData.count) bytes")
-        
+
         // Create a simple ZIP using a basic implementation
         let zipData = try createSimpleZip(files: [
             "index.json": indexData,
-            "term_bank_1.json": termsData
+            "term_bank_1.json": termsData,
         ])
-        
+
         print("🗂️ Final ZIP contains files: index.json, term_bank_1.json")
         return zipData
     }
-    
+
     /// Create a simple ZIP archive with the given files
     private func createSimpleZip(files: [String: Data]) throws -> Data {
         // Create a minimal ZIP file structure manually
         // This creates a basic ZIP file compatible with the existing extractor
-        
+
         var zipData = Data()
         var centralDirectory = Data()
         var localHeaderOffset: UInt32 = 0
-        
+
         for (filename, fileData) in files {
             // Local file header
             let localHeader = createLocalFileHeader(filename: filename, fileData: fileData)
             let localHeaderSize = UInt32(localHeader.count)
-            
+
             // Add local header and file data to ZIP
             zipData.append(localHeader)
             zipData.append(fileData)
-            
+
             // Create central directory entry
             let centralDirEntry = createCentralDirectoryEntry(
                 filename: filename,
@@ -412,14 +426,14 @@ class DictionaryImportManager: ObservableObject {
                 localHeaderOffset: localHeaderOffset
             )
             centralDirectory.append(centralDirEntry)
-            
+
             localHeaderOffset += localHeaderSize + UInt32(fileData.count)
         }
-        
+
         // Add central directory to ZIP
         let centralDirOffset = UInt32(zipData.count)
         zipData.append(centralDirectory)
-        
+
         // Add end of central directory record
         let endRecord = createEndOfCentralDirectoryRecord(
             entryCount: UInt16(files.count),
@@ -427,71 +441,75 @@ class DictionaryImportManager: ObservableObject {
             centralDirOffset: centralDirOffset
         )
         zipData.append(endRecord)
-        
+
         return zipData
     }
-    
+
     private func createLocalFileHeader(filename: String, fileData: Data) -> Data {
         var header = Data()
         let filenameData = filename.data(using: .utf8)!
-        
-        header.append(UInt32(0x04034b50).littleEndianData) // Local file header signature
-        header.append(UInt16(20).littleEndianData)          // Version needed to extract
-        header.append(UInt16(0).littleEndianData)           // General purpose bit flag
-        header.append(UInt16(0).littleEndianData)           // Compression method (no compression)
-        header.append(UInt16(0).littleEndianData)           // Last mod file time
-        header.append(UInt16(0).littleEndianData)           // Last mod file date
-        header.append(UInt32(0).littleEndianData)           // CRC-32 (we'll skip for simplicity)
-        header.append(UInt32(fileData.count).littleEndianData) // Compressed size
-        header.append(UInt32(fileData.count).littleEndianData) // Uncompressed size
-        header.append(UInt16(filenameData.count).littleEndianData) // Filename length
-        header.append(UInt16(0).littleEndianData)           // Extra field length
-        header.append(filenameData)                         // Filename
-        
+
+        header.append(UInt32(0x0403_4b50).littleEndianData)  // Local file header signature
+        header.append(UInt16(20).littleEndianData)  // Version needed to extract
+        header.append(UInt16(0).littleEndianData)  // General purpose bit flag
+        header.append(UInt16(0).littleEndianData)  // Compression method (no compression)
+        header.append(UInt16(0).littleEndianData)  // Last mod file time
+        header.append(UInt16(0).littleEndianData)  // Last mod file date
+        header.append(UInt32(0).littleEndianData)  // CRC-32 (we'll skip for simplicity)
+        header.append(UInt32(fileData.count).littleEndianData)  // Compressed size
+        header.append(UInt32(fileData.count).littleEndianData)  // Uncompressed size
+        header.append(UInt16(filenameData.count).littleEndianData)  // Filename length
+        header.append(UInt16(0).littleEndianData)  // Extra field length
+        header.append(filenameData)  // Filename
+
         return header
     }
-    
-    private func createCentralDirectoryEntry(filename: String, fileData: Data, localHeaderOffset: UInt32) -> Data {
+
+    private func createCentralDirectoryEntry(
+        filename: String, fileData: Data, localHeaderOffset: UInt32
+    ) -> Data {
         var entry = Data()
         let filenameData = filename.data(using: .utf8)!
-        
-        entry.append(UInt32(0x02014b50).littleEndianData)   // Central directory signature
-        entry.append(UInt16(20).littleEndianData)           // Version made by
-        entry.append(UInt16(20).littleEndianData)           // Version needed to extract
-        entry.append(UInt16(0).littleEndianData)            // General purpose bit flag
-        entry.append(UInt16(0).littleEndianData)            // Compression method
-        entry.append(UInt16(0).littleEndianData)            // Last mod file time
-        entry.append(UInt16(0).littleEndianData)            // Last mod file date
-        entry.append(UInt32(0).littleEndianData)            // CRC-32
-        entry.append(UInt32(fileData.count).littleEndianData) // Compressed size
-        entry.append(UInt32(fileData.count).littleEndianData) // Uncompressed size
-        entry.append(UInt16(filenameData.count).littleEndianData) // Filename length
-        entry.append(UInt16(0).littleEndianData)            // Extra field length
-        entry.append(UInt16(0).littleEndianData)            // File comment length
-        entry.append(UInt16(0).littleEndianData)            // Disk number start
-        entry.append(UInt16(0).littleEndianData)            // Internal file attributes
-        entry.append(UInt32(0).littleEndianData)            // External file attributes
-        entry.append(localHeaderOffset.littleEndianData)    // Local header offset
-        entry.append(filenameData)                          // Filename
-        
+
+        entry.append(UInt32(0x0201_4b50).littleEndianData)  // Central directory signature
+        entry.append(UInt16(20).littleEndianData)  // Version made by
+        entry.append(UInt16(20).littleEndianData)  // Version needed to extract
+        entry.append(UInt16(0).littleEndianData)  // General purpose bit flag
+        entry.append(UInt16(0).littleEndianData)  // Compression method
+        entry.append(UInt16(0).littleEndianData)  // Last mod file time
+        entry.append(UInt16(0).littleEndianData)  // Last mod file date
+        entry.append(UInt32(0).littleEndianData)  // CRC-32
+        entry.append(UInt32(fileData.count).littleEndianData)  // Compressed size
+        entry.append(UInt32(fileData.count).littleEndianData)  // Uncompressed size
+        entry.append(UInt16(filenameData.count).littleEndianData)  // Filename length
+        entry.append(UInt16(0).littleEndianData)  // Extra field length
+        entry.append(UInt16(0).littleEndianData)  // File comment length
+        entry.append(UInt16(0).littleEndianData)  // Disk number start
+        entry.append(UInt16(0).littleEndianData)  // Internal file attributes
+        entry.append(UInt32(0).littleEndianData)  // External file attributes
+        entry.append(localHeaderOffset.littleEndianData)  // Local header offset
+        entry.append(filenameData)  // Filename
+
         return entry
     }
-    
-    private func createEndOfCentralDirectoryRecord(entryCount: UInt16, centralDirSize: UInt32, centralDirOffset: UInt32) -> Data {
+
+    private func createEndOfCentralDirectoryRecord(
+        entryCount: UInt16, centralDirSize: UInt32, centralDirOffset: UInt32
+    ) -> Data {
         var record = Data()
-        
-        record.append(UInt32(0x06054b50).littleEndianData)  // End of central dir signature
-        record.append(UInt16(0).littleEndianData)           // Number of this disk
-        record.append(UInt16(0).littleEndianData)           // Disk where central directory starts
-        record.append(entryCount.littleEndianData)          // Number of central directory records on this disk
-        record.append(entryCount.littleEndianData)          // Total number of central directory records
-        record.append(centralDirSize.littleEndianData)      // Size of central directory
-        record.append(centralDirOffset.littleEndianData)    // Offset of start of central directory
-        record.append(UInt16(0).littleEndianData)           // ZIP file comment length
-        
+
+        record.append(UInt32(0x0605_4b50).littleEndianData)  // End of central dir signature
+        record.append(UInt16(0).littleEndianData)  // Number of this disk
+        record.append(UInt16(0).littleEndianData)  // Disk where central directory starts
+        record.append(entryCount.littleEndianData)  // Number of central directory records on this disk
+        record.append(entryCount.littleEndianData)  // Total number of central directory records
+        record.append(centralDirSize.littleEndianData)  // Size of central directory
+        record.append(centralDirOffset.littleEndianData)  // Offset of start of central directory
+        record.append(UInt16(0).littleEndianData)  // ZIP file comment length
+
         return record
     }
-    
+
     private func generateDatabaseURL() throws -> URL {
         let documentsURL = try FileManager.default.url(
             for: .documentDirectory,
@@ -499,23 +517,23 @@ class DictionaryImportManager: ObservableObject {
             appropriateFor: nil,
             create: true
         )
-        
+
         let dictionariesURL = documentsURL.appendingPathComponent("ImportedDictionaries")
-        
+
         // Create directory if it doesn't exist
         try FileManager.default.createDirectory(
             at: dictionariesURL,
             withIntermediateDirectories: true,
             attributes: nil
         )
-        
+
         // Generate unique filename
         let timestamp = Int(Date().timeIntervalSince1970)
         let filename = "imported_dictionary_\(timestamp).db"
-        
+
         return dictionariesURL.appendingPathComponent(filename)
     }
-    
+
     private func registerImportedDictionary(at databaseURL: URL, index: YomitanIndex) throws {
         // Store dictionary metadata for future reference - only store filename
         let filename = databaseURL.lastPathComponent
@@ -528,29 +546,30 @@ class DictionaryImportManager: ObservableObject {
             databaseFilename: filename,
             importDate: Date()
         )
-        
+
         // Save to registry
         saveToRegistry(info)
-        
+
         // Notify DictionaryManager about new dictionary
         DictionaryManager.shared.reloadImportedDictionaries()
     }
-    
+
     private func saveToRegistry(_ info: ImportedDictionaryInfo) {
         var registry = loadRegistry()
         registry.append(info)
-        
+
         if let data = try? JSONEncoder().encode(registry) {
             UserDefaults.standard.set(data, forKey: "ImportedDictionaries")
         }
     }
-    
+
     private func loadRegistry() -> [ImportedDictionaryInfo] {
         guard let data = UserDefaults.standard.data(forKey: "ImportedDictionaries"),
-              let registry = try? JSONDecoder().decode([ImportedDictionaryInfo].self, from: data) else {
+            let registry = try? JSONDecoder().decode([ImportedDictionaryInfo].self, from: data)
+        else {
             return []
         }
-        
+
         // Clean up registry: remove entries for files that no longer exist
         let validEntries = registry.filter { info in
             let fileExists = FileManager.default.fileExists(atPath: info.databaseURL.path)
@@ -558,14 +577,14 @@ class DictionaryImportManager: ObservableObject {
             }
             return fileExists
         }
-        
+
         // Save cleaned registry if it changed
         if validEntries.count != registry.count {
             if let data = try? JSONEncoder().encode(validEntries) {
                 UserDefaults.standard.set(data, forKey: "ImportedDictionaries")
             }
         }
-        
+
         return validEntries
     }
 }
@@ -576,7 +595,7 @@ enum ImportError: Error, LocalizedError {
     case invalidJSONFormat(String)
     case unsupportedJSONFormat(String)
     case zipCreationFailed(String)
-    
+
     var errorDescription: String? {
         switch self {
         case .fileNotAccessible(let message):
@@ -601,11 +620,14 @@ struct ImportedDictionaryInfo: Codable, Identifiable {
     let description: String?
     let databaseFilename: String  // Store just the filename, not full path
     let importDate: Date
-    
+
     // Support for legacy entries that stored full URLs
     private let legacyDatabaseURL: URL?
-    
-    init(title: String, revision: String, version: Int, author: String?, description: String?, databaseFilename: String, importDate: Date) {
+
+    init(
+        title: String, revision: String, version: Int, author: String?, description: String?,
+        databaseFilename: String, importDate: Date
+    ) {
         self.id = UUID()
         self.title = title
         self.revision = revision
@@ -616,11 +638,11 @@ struct ImportedDictionaryInfo: Codable, Identifiable {
         self.importDate = importDate
         self.legacyDatabaseURL = nil
     }
-    
+
     // Custom decoder to handle legacy format
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        
+
         self.id = (try? container.decode(UUID.self, forKey: .id)) ?? UUID()
         self.title = try container.decode(String.self, forKey: .title)
         self.revision = try container.decode(String.self, forKey: .revision)
@@ -628,7 +650,7 @@ struct ImportedDictionaryInfo: Codable, Identifiable {
         self.author = try? container.decode(String.self, forKey: .author)
         self.description = try? container.decode(String.self, forKey: .description)
         self.importDate = try container.decode(Date.self, forKey: .importDate)
-        
+
         // Handle legacy databaseURL vs new databaseFilename
         if let filename = try? container.decode(String.self, forKey: .databaseFilename) {
             // New format
@@ -639,35 +661,39 @@ struct ImportedDictionaryInfo: Codable, Identifiable {
             self.databaseFilename = url.lastPathComponent
             self.legacyDatabaseURL = url
         } else {
-            throw DecodingError.keyNotFound(CodingKeys.databaseFilename, DecodingError.Context(codingPath: decoder.codingPath, debugDescription: "Missing databaseFilename or legacyDatabaseURL"))
+            throw DecodingError.keyNotFound(
+                CodingKeys.databaseFilename,
+                DecodingError.Context(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "Missing databaseFilename or legacyDatabaseURL"))
         }
     }
-    
+
     private enum CodingKeys: String, CodingKey {
         case id, title, revision, version, author, description, databaseFilename, importDate
         case legacyDatabaseURL = "databaseURL"
     }
-    
+
     var displayName: String {
         return title
     }
-    
+
     var detailText: String {
         var details: [String] = []
-        
+
         if let author = author, !author.isEmpty {
             details.append("by \(author)")
         }
-        
+
         details.append("v\(revision)")
-        
+
         let formatter = DateFormatter()
         formatter.dateStyle = .medium
         details.append("imported \(formatter.string(from: importDate))")
-        
+
         return details.joined(separator: " • ")
     }
-    
+
     /// Get the full database URL using current Documents directory
     var databaseURL: URL {
         do {
@@ -677,7 +703,8 @@ struct ImportedDictionaryInfo: Codable, Identifiable {
                 appropriateFor: nil,
                 create: false
             )
-            return documentsURL
+            return
+                documentsURL
                 .appendingPathComponent("ImportedDictionaries")
                 .appendingPathComponent(databaseFilename)
         } catch {

--- a/Shiori Reader/Features/DictionaryImport/DictionaryManager+YomitanImport.swift
+++ b/Shiori Reader/Features/DictionaryImport/DictionaryManager+YomitanImport.swift
@@ -109,7 +109,8 @@ extension DictionaryManager {
         return allEntries
     }
     
-    func lookupImportedFrequencies(word: String) -> [FrequencyData] {
+    /// Lookup frequency data concurrently from all dictionaries
+    func lookupImportedFrequencies(word: String, reading: String) -> [FrequencyData] {
         let startTime = CFAbsoluteTimeGetCurrent()
         let enabledDictionaries = getEnabledDictionaries()
         
@@ -134,7 +135,7 @@ extension DictionaryManager {
             dispatchGroup.enter()
             
             concurrentQueue.async {
-                let frequency = FrequencyManager.shared.getImportedFrequencyData(for: word, db: queue, dictionaryKey: dictionaryKey)
+                let frequency = FrequencyManager.shared.getImportedFrequencyData(for: word, with: reading, db: queue, dictionaryKey: dictionaryKey)
                     
                 resultQueue.async {
                     if let frequency = frequency {
@@ -187,7 +188,7 @@ extension DictionaryManager {
         
         
         // Lookup and add all frequencies to the entry
-        var frequencyData: [FrequencyData] = lookupImportedFrequencies(word: term)
+        var frequencyData: [FrequencyData] = lookupImportedFrequencies(word: term, reading: reading)
         
         if let BCCWJFrequency = FrequencyManager.shared.getBCCWJFrequencyData(for: term), getEnabledDictionaries().contains("bccwj") {
             frequencyData += [BCCWJFrequency]

--- a/Shiori Reader/Features/DictionaryImport/DictionaryManager+YomitanImport.swift
+++ b/Shiori Reader/Features/DictionaryImport/DictionaryManager+YomitanImport.swift
@@ -187,13 +187,26 @@ extension DictionaryManager {
         
         
         // Lookup and add all frequencies to the entry
-        let importedFrequencies = lookupImportedFrequencies(word: term)
+        var frequencyData: [FrequencyData] = lookupImportedFrequencies(word: term)
         
-        if let BCCWJFrequency = FrequencyManager.shared.getBCCWJFrequencyData(for: term) {
-            entry.frequencyData = importedFrequencies + [BCCWJFrequency]
-        } else {
-            entry.frequencyData = importedFrequencies
+        if let BCCWJFrequency = FrequencyManager.shared.getBCCWJFrequencyData(for: term), getEnabledDictionaries().contains("bccwj") {
+            frequencyData += [BCCWJFrequency]
         }
+        
+        // Order frequencies by user's chosen source order
+        let orderedSources = DictionaryColorProvider.shared.getOrderedDictionarySources()
+        frequencyData.sort { (lhs, rhs) -> Bool in
+            guard let lhsIndex = orderedSources.firstIndex(of: lhs.source) else {
+                return false
+            }
+            
+            guard let rhsIndex = orderedSources.firstIndex(of: rhs.source) else {
+                return false
+            }
+            return lhsIndex < rhsIndex
+        }
+        
+        entry.frequencyData = frequencyData
         
         return entry
     }

--- a/Shiori Reader/Features/Reader/Views/DictionaryPopupCardView.swift
+++ b/Shiori Reader/Features/Reader/Views/DictionaryPopupCardView.swift
@@ -148,15 +148,11 @@ struct DictionaryPopupCardView: View {
                                 .padding(.vertical, 4)
                                 
                                 // Display frequency data if available and BCCWJ is enabled
-                                if isBCCWJEnabled(), let frequencyRank = entry.frequencyRankString {
+                                if isBCCWJEnabled() {
                                     HStack {
-                                        Text(frequencyRank)
-                                            .font(.caption2)
-                                            .padding(.horizontal, 4)
-                                            .padding(.vertical, 1)
-                                            .background(Color.green.opacity(0.2))
-                                            .foregroundColor(.green)
-                                            .cornerRadius(4)
+                                        ForEach(entry.frequencyData, id: \.source) {frequencyData in
+                                            getFrequencyBadge(for: frequencyData.source, frequencyRank: "\(frequencyData.frequency)")
+                                        }
                                         Spacer()
                                     }
                                     .padding(.bottom, 4)
@@ -672,6 +668,31 @@ struct DictionaryPopupCardView: View {
             Text(displayName)
                 .font(.caption2)
                 .padding(.horizontal, 4)
+                .padding(.vertical, 1)
+                .background(color.opacity(0.2))
+                .foregroundColor(color)
+                .cornerRadius(4)
+        }
+    }
+    
+    @ViewBuilder
+    private func getFrequencyBadge(for source: String, frequencyRank: String) -> some View {
+        let color = getDictionaryColor(for: source)
+        
+        if source == "BCCWJ" {
+            Text("BCCWJ: \(frequencyRank)")
+                .font(.caption2)
+                .padding(.horizontal, 5)
+                .padding(.vertical, 1)
+                .background(Color.green.opacity(0.2))
+                .foregroundColor(.green)
+                .cornerRadius(4)
+        } else if source.hasPrefix("imported_") {
+            let displayName = getImportedDictionaryDisplayName(source: source)
+            
+            Text("\(displayName): \(frequencyRank)")
+                .font(.caption2)
+                .padding(.horizontal, 5)
                 .padding(.vertical, 1)
                 .background(color.opacity(0.2))
                 .foregroundColor(color)

--- a/Shiori Reader/Features/Reader/Views/DictionaryPopupCardView.swift
+++ b/Shiori Reader/Features/Reader/Views/DictionaryPopupCardView.swift
@@ -147,8 +147,7 @@ struct DictionaryPopupCardView: View {
                                 }
                                 .padding(.vertical, 4)
                                 
-                                // Display frequency data
-                                FlowLayout {
+                                FlowLayout(spacing: 4) {
                                     ForEach(entry.frequencyData, id: \.source) {frequencyData in
                                         getFrequencyBadge(for: frequencyData.source, frequencyRank: "\(frequencyData.frequency)")
                                     }
@@ -677,7 +676,7 @@ struct DictionaryPopupCardView: View {
     private func getFrequencyBadge(for source: String, frequencyRank: String) -> some View {
         let color = getDictionaryColor(for: source)
         
-        if source == "BCCWJ" {
+        if source == "bccwj" {
             Text("BCCWJ: \(frequencyRank)")
                 .font(.caption2)
                 .padding(.horizontal, 5)

--- a/Shiori Reader/Features/Reader/Views/DictionaryPopupCardView.swift
+++ b/Shiori Reader/Features/Reader/Views/DictionaryPopupCardView.swift
@@ -147,16 +147,14 @@ struct DictionaryPopupCardView: View {
                                 }
                                 .padding(.vertical, 4)
                                 
-                                // Display frequency data if available and BCCWJ is enabled
-                                if isBCCWJEnabled() {
-                                    HStack {
-                                        ForEach(entry.frequencyData, id: \.source) {frequencyData in
-                                            getFrequencyBadge(for: frequencyData.source, frequencyRank: "\(frequencyData.frequency)")
-                                        }
-                                        Spacer()
+                                // Display frequency data
+                                FlowLayout {
+                                    ForEach(entry.frequencyData, id: \.source) {frequencyData in
+                                        getFrequencyBadge(for: frequencyData.source, frequencyRank: "\(frequencyData.frequency)")
                                     }
-                                    .padding(.bottom, 4)
+                                    Spacer()
                                 }
+                                .padding(.bottom, 4)
                                 
                                 // Display meanings grouped by source
                                 let entriesBySource = Dictionary(grouping: getAllEntriesForTerm(entry.term, reading: entry.reading, from: matches)) { $0.source }

--- a/Shiori Reader/Features/Reader/Views/DictionaryPopupView.swift
+++ b/Shiori Reader/Features/Reader/Views/DictionaryPopupView.swift
@@ -160,7 +160,7 @@ struct DictionaryPopupView: View {
                                 
                                 // Display frequency data if available and BCCWJ is enabled
                                 if isBCCWJEnabled() {
-                                    HStack() {
+                                    FlowLayout(spacing: 4) {
                                         ForEach(entry.frequencyData, id: \.source) {frequencyData in
                                             getFrequencyBadge(for: frequencyData.source, frequencyRank: "\(frequencyData.frequency)")
                                         }

--- a/Shiori Reader/Features/Reader/Views/DictionaryPopupView.swift
+++ b/Shiori Reader/Features/Reader/Views/DictionaryPopupView.swift
@@ -714,7 +714,7 @@ struct DictionaryPopupView: View {
     private func getFrequencyBadge(for source: String, frequencyRank: String) -> some View {
         let color = getDictionaryColor(for: source)
         
-        if source == "BCCWJ" {
+        if source == "bccwj" {
             Text("BCCWJ: \(frequencyRank)")
                 .font(.caption2)
                 .padding(.horizontal, 5)

--- a/Shiori Reader/Features/Reader/Views/DictionaryPopupView.swift
+++ b/Shiori Reader/Features/Reader/Views/DictionaryPopupView.swift
@@ -159,15 +159,11 @@ struct DictionaryPopupView: View {
                                 .padding(.vertical, 4)
                                 
                                 // Display frequency data if available and BCCWJ is enabled
-                                if isBCCWJEnabled(), let frequencyRank = entry.frequencyRankString {
-                                    HStack {
-                                        Text(frequencyRank)
-                                            .font(.caption2)
-                                            .padding(.horizontal, 4)
-                                            .padding(.vertical, 1)
-                                            .background(Color.green.opacity(0.2))
-                                            .foregroundColor(.green)
-                                            .cornerRadius(4)
+                                if isBCCWJEnabled() {
+                                    HStack() {
+                                        ForEach(entry.frequencyData, id: \.source) {frequencyData in
+                                            getFrequencyBadge(for: frequencyData.source, frequencyRank: "\(frequencyData.frequency)")
+                                        }
                                         Spacer()
                                     }
                                     .padding(.bottom, 4)
@@ -712,6 +708,31 @@ struct DictionaryPopupView: View {
     
     private func getAllEntriesForTerm(_ term: String, reading: String, from matches: [DictionaryMatch]) -> [DictionaryEntry] {
         return matches.flatMap { $0.entries }.filter { $0.term == term && $0.reading == reading }
+    }
+    
+    @ViewBuilder
+    private func getFrequencyBadge(for source: String, frequencyRank: String) -> some View {
+        let color = getDictionaryColor(for: source)
+        
+        if source == "BCCWJ" {
+            Text("BCCWJ: \(frequencyRank)")
+                .font(.caption2)
+                .padding(.horizontal, 5)
+                .padding(.vertical, 1)
+                .background(Color.green.opacity(0.2))
+                .foregroundColor(.green)
+                .cornerRadius(4)
+        } else if source.hasPrefix("imported_") {
+            let displayName = getImportedDictionaryDisplayName(source: source)
+            
+            Text("\(displayName): \(frequencyRank)")
+                .font(.caption2)
+                .padding(.horizontal, 5)
+                .padding(.vertical, 1)
+                .background(color.opacity(0.2))
+                .foregroundColor(color)
+                .cornerRadius(4)
+        }
     }
     
     @ViewBuilder

--- a/Shiori Reader/Features/Reader/Views/DictionaryPopupView.swift
+++ b/Shiori Reader/Features/Reader/Views/DictionaryPopupView.swift
@@ -158,16 +158,14 @@ struct DictionaryPopupView: View {
                                 }
                                 .padding(.vertical, 4)
                                 
-                                // Display frequency data if available and BCCWJ is enabled
-                                if isBCCWJEnabled() {
-                                    FlowLayout(spacing: 4) {
-                                        ForEach(entry.frequencyData, id: \.source) {frequencyData in
-                                            getFrequencyBadge(for: frequencyData.source, frequencyRank: "\(frequencyData.frequency)")
-                                        }
-                                        Spacer()
+                                // Display frequency data if available
+                                FlowLayout(spacing: 4) {
+                                    ForEach(entry.frequencyData, id: \.source) {frequencyData in
+                                        getFrequencyBadge(for: frequencyData.source, frequencyRank: "\(frequencyData.frequency)")
                                     }
-                                    .padding(.bottom, 4)
+                                    Spacer()
                                 }
+                                .padding(.bottom, 4)
                                 
                                 // Display meanings grouped by source
                                 let entriesBySource = Dictionary(grouping: getAllEntriesForTerm(entry.term, reading: entry.reading, from: matches)) { $0.source }

--- a/Shiori Reader/Features/Search/DictionaryEntryRow.swift
+++ b/Shiori Reader/Features/Search/DictionaryEntryRow.swift
@@ -3,7 +3,7 @@ import SwiftUI
 // Component for dictionary entry row
 struct DictionaryEntryRow: View {
     let entry: DictionaryEntry
-
+    
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(alignment: .center) {
@@ -16,22 +16,22 @@ struct DictionaryEntryRow: View {
                             .foregroundColor(.secondary)
                             .padding(.bottom, 1)
                     }
-
+                    
                     // Main term
                     Text(entry.term)
                         .font(.headline)
                         .foregroundColor(.primary)
                 }
-                .layoutPriority(1)  // Give term highest priority
+                .layoutPriority(1) // Give term highest priority
                 .fixedSize(horizontal: false, vertical: true)
-
+                
                 // Pitch accent graphs in horizontal scroll view
                 if entry.hasPitchAccent, let pitchAccents = entry.pitchAccents {
                     // Filter to only show graphs that match both term AND reading
                     let matchingAccents = pitchAccents.accents.filter { accent in
                         accent.term == entry.term && accent.reading == entry.reading
                     }
-
+                    
                     if !matchingAccents.isEmpty {
                         // Scrollable container for pitch accent graphs
                         ScrollView(.horizontal, showsIndicators: false) {
@@ -46,13 +46,13 @@ struct DictionaryEntryRow: View {
                             }
                             .padding(.horizontal, 4)
                         }
-                        .padding(.leading, 8)  // Small gap from the word
-                        .layoutPriority(0)  // Lower priority than term
+                        .padding(.leading, 8) // Small gap from the word
+                        .layoutPriority(0) // Lower priority than term
                     }
                 }
-
+                
                 Spacer(minLength: 8)
-
+                
                 // Optional: Show tags or indicators for word types
                 if !entry.termTags.isEmpty {
                     Text(entry.termTags.first ?? "")
@@ -64,7 +64,7 @@ struct DictionaryEntryRow: View {
                         .cornerRadius(4)
                 }
             }
-
+            
             // Dictionary source badges and frequency data with flow layout
             FlowLayout(spacing: 4) {
                 // Frequency data first (if available and BCCWJ is enabled)
@@ -74,13 +74,13 @@ struct DictionaryEntryRow: View {
                             for: frequencyData.source, frequencyRank: "\(frequencyData.frequency)")
                     }
                 }
-
+                
                 // Show dictionary badges based on source
                 if entry.source == "combined" {
                     // For combined entries, show all available dictionary badges
                     let allEntries = getAllEntriesForWord()
                     let uniqueSources = Array(Set(allEntries.map { $0.source })).sorted()
-
+                    
                     ForEach(uniqueSources, id: \.self) { source in
                         getDictionarySourceBadge(for: source)
                     }
@@ -90,13 +90,13 @@ struct DictionaryEntryRow: View {
                 }
             }
             .padding(.bottom, 2)
-
+            
             // Show first meaning
             Text(entry.meanings.first ?? "")
                 .font(.subheadline)
                 .foregroundColor(.secondary)
                 .lineLimit(1)
-
+            
             // Indicate if there are more meanings
             if entry.meanings.count > 1 {
                 Text("+\(entry.meanings.count - 1) more meanings")
@@ -106,21 +106,21 @@ struct DictionaryEntryRow: View {
         }
         .padding(.vertical, 4)
     }
-
+    
     private func getDictionaryColor(for source: String) -> Color {
         return DictionaryColorProvider.shared.getColor(for: source)
     }
-
+    
     private func getAllEntriesForWord() -> [DictionaryEntry] {
         // Use the same lookup method as SearchViewModel to include imported dictionaries
         let allEntries = DictionaryManager.shared.lookupWithDeinflection(word: entry.term)
         return allEntries.filter { $0.term == entry.term && $0.reading == entry.reading }
     }
-
+    
     @ViewBuilder
     private func getDictionarySourceBadge(for source: String) -> some View {
         let color = getDictionaryColor(for: source)
-
+        
         if source == "jmdict" {
             Text("JMdict")
                 .font(.caption2)
@@ -132,7 +132,7 @@ struct DictionaryEntryRow: View {
                 .cornerRadius(4)
         } else if source.hasPrefix("imported_") {
             let displayName = getImportedDictionaryDisplayName(source: source)
-
+            
             Text(displayName)
                 .font(.caption2)
                 .lineLimit(1)
@@ -190,17 +190,16 @@ struct DictionaryEntryRow: View {
         }
         return "Imported"
     }
-
+    
     /// Check if BCCWJ frequency data is enabled in settings
     private func isBCCWJEnabled() -> Bool {
         // Simple struct to decode settings
         struct SimpleDictionarySettings: Codable {
             var enabledDictionaries: [String]
         }
-
+        
         if let data = UserDefaults.standard.data(forKey: "dictionarySettings"),
-            let settings = try? JSONDecoder().decode(SimpleDictionarySettings.self, from: data)
-        {
+           let settings = try? JSONDecoder().decode(SimpleDictionarySettings.self, from: data) {
             return settings.enabledDictionaries.contains("bccwj")
         }
         // Default to true for backward compatibility

--- a/Shiori Reader/Features/Search/DictionaryEntryRow.swift
+++ b/Shiori Reader/Features/Search/DictionaryEntryRow.swift
@@ -68,14 +68,14 @@ struct DictionaryEntryRow: View {
             // Dictionary source badges and frequency data with flow layout
             FlowLayout(spacing: 4) {
                 // Frequency data first (if available and BCCWJ is enabled)
-                if isBCCWJEnabled(), let frequencyRank = entry.frequencyRankString {
-                    Text(frequencyRank)
-                        .font(.caption2)
-                        .padding(.horizontal, 4)
-                        .padding(.vertical, 1)
-                        .background(Color.green.opacity(0.2))
-                        .foregroundColor(.green)
-                        .cornerRadius(4)
+                if isBCCWJEnabled() {
+//                    Text(frequencyRank)
+//                        .font(.caption2)
+//                        .padding(.horizontal, 4)
+//                        .padding(.vertical, 1)
+//                        .background(Color.green.opacity(0.2))
+//                        .foregroundColor(.green)
+//                        .cornerRadius(4)
                 }
                 
                 // Show dictionary badges based on source

--- a/Shiori Reader/Features/Search/DictionaryEntryRow.swift
+++ b/Shiori Reader/Features/Search/DictionaryEntryRow.swift
@@ -68,11 +68,9 @@ struct DictionaryEntryRow: View {
             // Dictionary source badges and frequency data with flow layout
             FlowLayout(spacing: 4) {
                 // Frequency data first
-                if isBCCWJEnabled() {
-                    ForEach(entry.frequencyData, id: \.source) { frequencyData in
-                        getFrequencyBadge(
-                            for: frequencyData.source, frequencyRank: "\(frequencyData.frequency)")
-                    }
+                ForEach(entry.frequencyData, id: \.source) { frequencyData in
+                    getFrequencyBadge(
+                        for: frequencyData.source, frequencyRank: "\(frequencyData.frequency)")
                 }
                 
                 // Show dictionary badges based on source

--- a/Shiori Reader/Features/Search/DictionaryEntryRow.swift
+++ b/Shiori Reader/Features/Search/DictionaryEntryRow.swift
@@ -67,7 +67,7 @@ struct DictionaryEntryRow: View {
             
             // Dictionary source badges and frequency data with flow layout
             FlowLayout(spacing: 4) {
-                // Frequency data first (if available and BCCWJ is enabled)
+                // Frequency data first
                 if isBCCWJEnabled() {
                     ForEach(entry.frequencyData, id: \.source) { frequencyData in
                         getFrequencyBadge(

--- a/Shiori Reader/Features/Search/DictionaryEntryRow.swift
+++ b/Shiori Reader/Features/Search/DictionaryEntryRow.swift
@@ -158,7 +158,7 @@ struct DictionaryEntryRow: View {
     private func getFrequencyBadge(for source: String, frequencyRank: String) -> some View {
         let color = getDictionaryColor(for: source)
 
-        if source == "BCCWJ" {
+        if source == "bccwj" {
             Text("BCCWJ: \(frequencyRank)")
                 .font(.caption2)
                 .padding(.horizontal, 5)

--- a/Shiori Reader/Services/Dictionary/DictionaryManager.swift
+++ b/Shiori Reader/Services/Dictionary/DictionaryManager.swift
@@ -98,9 +98,17 @@ class DictionaryManager {
         )
         
         // Add frequency data if available and BCCWJ is enabled
-        if isBCCWJEnabled() {
-            entry.frequencyData = frequencyManager.getFrequencyData(for: term) + lookupImportedFrequencies(word: term)
+        // Lookup and add all frequencies to the entry
+        let importedFrequencies = lookupImportedFrequencies(word: term)
+        
+        if let BCCWJFrequency = FrequencyManager.shared.getBCCWJFrequencyData(for: term),
+        isBCCWJEnabled() {
+            entry.frequencyData = importedFrequencies + [BCCWJFrequency]
+        } else {
+            entry.frequencyData = importedFrequencies
         }
+        
+        return entry
         
         // Pitch accents will be loaded lazily via the computed property
         return entry

--- a/Shiori Reader/Services/Dictionary/DictionaryManager.swift
+++ b/Shiori Reader/Services/Dictionary/DictionaryManager.swift
@@ -98,7 +98,7 @@ class DictionaryManager {
         )
         
         // Lookup and add all frequencies to the entry
-        var frequencyData: [FrequencyData] = lookupImportedFrequencies(word: term)
+        var frequencyData: [FrequencyData] = lookupImportedFrequencies(word: term, reading: reading)
         
         if let BCCWJFrequency = FrequencyManager.shared.getBCCWJFrequencyData(for: term), isBCCWJEnabled() {
             frequencyData += [BCCWJFrequency]

--- a/Shiori Reader/Services/Dictionary/DictionaryManager.swift
+++ b/Shiori Reader/Services/Dictionary/DictionaryManager.swift
@@ -884,19 +884,19 @@ class DictionaryManager {
         
         let testWords = ["猫", "日本", "最初", "食べる", "本", "私", "今日"]
         
-//        for word in testWords {
-//            if let frequencyData = frequencyManager.getFrequencyData(for: word) {
-//                print("🧪 [FREQUENCY TEST] '\(word)': rank=\(frequencyData.rank), freq=\(frequencyData.frequency), source=\(frequencyData.source)")
-//            } else {
-//                print("🧪 [FREQUENCY TEST] '\(word)': No frequency data found")
-//            }
-//        }
+        for word in testWords {
+            if let frequencyData = frequencyManager.getBCCWJFrequencyData(for: word) {
+                print("🧪 [FREQUENCY TEST] '\(word)': rank=\(frequencyData.rank), freq=\(frequencyData.frequency), source=\(frequencyData.source)")
+            } else {
+                print("🧪 [FREQUENCY TEST] '\(word)': No frequency data found")
+            }
+        }
         
         // Test with actual dictionary lookup
         print("🧪 [FREQUENCY TEST] Testing with dictionary lookup...")
         let testEntries = lookupWithDeinflection(word: "猫")
         for entry in testEntries {
-//            print("🧪 [FREQUENCY TEST] Entry '\(entry.term)' has frequency: \(entry.hasFrequencyData ? entry.frequencyRankString ?? "unknown" : "none")")
+            print("🧪 [FREQUENCY TEST] Entry '\(entry.term)' has frequency: \(entry.hasFrequencyData ? entry.frequencyRankStrings.getOrNil(0) ?? "unknown" : "none")")
         }
     }
     

--- a/Shiori Reader/Services/Dictionary/DictionaryManager.swift
+++ b/Shiori Reader/Services/Dictionary/DictionaryManager.swift
@@ -98,8 +98,8 @@ class DictionaryManager {
         )
         
         // Add frequency data if available and BCCWJ is enabled
-        if isBCCWJEnabled(), let frequencyData = frequencyManager.getFrequencyData(for: term) {
-            entry.frequencyData = frequencyData
+        if isBCCWJEnabled() {
+            entry.frequencyData = frequencyManager.getFrequencyData(for: term) + lookupImportedFrequencies(word: term)
         }
         
         // Pitch accents will be loaded lazily via the computed property
@@ -876,19 +876,19 @@ class DictionaryManager {
         
         let testWords = ["猫", "日本", "最初", "食べる", "本", "私", "今日"]
         
-        for word in testWords {
-            if let frequencyData = frequencyManager.getFrequencyData(for: word) {
-                print("🧪 [FREQUENCY TEST] '\(word)': rank=\(frequencyData.rank), freq=\(frequencyData.frequency), source=\(frequencyData.source)")
-            } else {
-                print("🧪 [FREQUENCY TEST] '\(word)': No frequency data found")
-            }
-        }
+//        for word in testWords {
+//            if let frequencyData = frequencyManager.getFrequencyData(for: word) {
+//                print("🧪 [FREQUENCY TEST] '\(word)': rank=\(frequencyData.rank), freq=\(frequencyData.frequency), source=\(frequencyData.source)")
+//            } else {
+//                print("🧪 [FREQUENCY TEST] '\(word)': No frequency data found")
+//            }
+//        }
         
         // Test with actual dictionary lookup
         print("🧪 [FREQUENCY TEST] Testing with dictionary lookup...")
         let testEntries = lookupWithDeinflection(word: "猫")
         for entry in testEntries {
-            print("🧪 [FREQUENCY TEST] Entry '\(entry.term)' has frequency: \(entry.hasFrequencyData ? entry.frequencyRankString ?? "unknown" : "none")")
+//            print("🧪 [FREQUENCY TEST] Entry '\(entry.term)' has frequency: \(entry.hasFrequencyData ? entry.frequencyRankString ?? "unknown" : "none")")
         }
     }
     

--- a/Shiori Reader/Services/Dictionary/FrequencyManager.swift
+++ b/Shiori Reader/Services/Dictionary/FrequencyManager.swift
@@ -35,7 +35,7 @@ class FrequencyManager {
     }
 
     /// Get frequency data for a specific word (optimized version)
-    private func getBCCWJFrequencyData(for word: String) -> FrequencyData? {
+    func getBCCWJFrequencyData(for word: String) -> FrequencyData? {
         guard let db = bccwjQueue else { return nil }
 
         do {
@@ -81,14 +81,15 @@ class FrequencyManager {
         }
     }
 
-    func decodeFrequencyJson(json rawJson: String) throws -> Int? {
+    /// Get the frequency number from the "data" field json string in a term bank.
+    func decodeFrequencyJson(json rawJson: String) -> Int? {
         let jsonData = rawJson.data(using: .utf8)!
 
         if let jsonFrequency = Int(rawJson) {
             return jsonFrequency
         }
 
-        let jsonObj = try JSONSerialization.jsonObject(with: jsonData, options: [])
+        let jsonObj = try? JSONSerialization.jsonObject(with: jsonData, options: [])
 
         if let jsonObj = jsonObj as? [String: Any] {
             if let value = jsonObj["value"],
@@ -115,6 +116,7 @@ class FrequencyManager {
         return nil
     }
 
+    /// Get frequency data from an imported dictionary
     func getImportedFrequencyData(for word: String, db: DatabaseQueue, dictionaryKey: String)
         -> FrequencyData?
     {
@@ -130,12 +132,12 @@ class FrequencyManager {
                         """, arguments: [word])
 
                 if let row = rows.first {
-                    let term = row["expression"] as String
-                    let mode = row["mode"] as String
-                    let data = row["data"] as String
+                    let term = row["expression"] as! String
+                    let mode = row["mode"] as! String
+                    let data = row["data"] as! String
 
                     if mode == "freq" {
-                        let frequency = try decodeFrequencyJson(json: data)
+                        let frequency = decodeFrequencyJson(json: data)
 
                         if let frequency = frequency {
                             return FrequencyData(
@@ -155,17 +157,7 @@ class FrequencyManager {
             return nil
         }
     }
-
-    func getFrequencyData(for word: String) -> [FrequencyData] {
-        var frequencyData: [FrequencyData] = []
-
-        if let data = getBCCWJFrequencyData(for: word) {
-            frequencyData.append(data)
-        }
-
-        return frequencyData
-    }
-
+    
     /// Get frequency rank for display (returns a formatted string)
     func getFrequencyRank(for word: String) -> String? {
         guard let frequencyData = getBCCWJFrequencyData(for: word) else { return nil }

--- a/Shiori Reader/Services/Dictionary/FrequencyManager.swift
+++ b/Shiori Reader/Services/Dictionary/FrequencyManager.swift
@@ -11,13 +11,13 @@ struct FrequencyData {
 
 class FrequencyManager {
     static let shared = FrequencyManager()
-    
+
     private var bccwjQueue: DatabaseQueue?
-    
+
     private init() {
         setupDatabase()
     }
-    
+
     private func setupDatabase() {
         do {
             // Setup BCCWJ frequency database
@@ -33,24 +33,26 @@ class FrequencyManager {
             print("Error setting up BCCWJ frequency database: \(error)")
         }
     }
-    
+
     /// Get frequency data for a specific word (optimized version)
-    func getFrequencyData(for word: String) -> FrequencyData? {
+    private func getBCCWJFrequencyData(for word: String) -> FrequencyData? {
         guard let db = bccwjQueue else { return nil }
-        
+
         do {
             return try db.read { db in
                 // Fast exact match query
-                let rows = try Row.fetchAll(db, sql: """
-                    SELECT term, frequency_value
-                    FROM frequency
-                    WHERE term = ?
-                    LIMIT 1
-                    """, arguments: [word])
-                
+                let rows = try Row.fetchAll(
+                    db,
+                    sql: """
+                        SELECT term, frequency_value
+                        FROM frequency
+                        WHERE term = ?
+                        LIMIT 1
+                        """, arguments: [word])
+
                 if let row = rows.first {
                     let term = row["term"] as? String ?? word
-                    
+
                     // Optimized parsing - try Int64 first (most common)
                     let frequencyValue: Int
                     if let int64Value = row["frequency_value"] as? Int64 {
@@ -60,7 +62,7 @@ class FrequencyManager {
                     } else {
                         frequencyValue = (try? Int.fromDatabaseValue(row["frequency_value"])) ?? 0
                     }
-                    
+
                     if frequencyValue > 0 {
                         return FrequencyData(
                             word: term,
@@ -71,43 +73,129 @@ class FrequencyManager {
                         )
                     }
                 }
-                
+
                 return nil
             }
         } catch {
             return nil
         }
     }
-    
+
+    func decodeFrequencyJson(json rawJson: String) throws -> Int? {
+        let jsonData = rawJson.data(using: .utf8)!
+
+        if let jsonFrequency = Int(rawJson) {
+            return jsonFrequency
+        }
+
+        let jsonObj = try JSONSerialization.jsonObject(with: jsonData, options: [])
+
+        if let jsonObj = jsonObj as? [String: Any] {
+            if let value = jsonObj["value"],
+                let jsonFrequency = value as? NSNumber
+            {
+                return jsonFrequency.intValue
+            }
+
+            if let jsonFrequency = jsonObj["frequency"] {
+
+                if let jsonFrequencyInt = jsonFrequency as? NSNumber {
+                    return jsonFrequencyInt.intValue
+                }
+
+                if let jsonObj = jsonFrequency as? [String: Any],
+                    let value = jsonObj["value"],
+                    let jsonFrequency = value as? NSNumber
+                {
+                    return jsonFrequency.intValue
+                }
+            }
+        }
+
+        return nil
+    }
+
+    func getImportedFrequencyData(for word: String, db: DatabaseQueue, dictionaryKey: String)
+        -> FrequencyData?
+    {
+        do {
+            return try db.read { db in
+                let rows = try Row.fetchAll(
+                    db,
+                    sql: """
+                        SELECT id, expression, mode, data, dictionary
+                        FROM term_meta
+                        WHERE expression = ?
+                        ORDER BY id
+                        """, arguments: [word])
+
+                if let row = rows.first {
+                    let term = row["expression"] as String
+                    let mode = row["mode"] as String
+                    let data = row["data"] as String
+
+                    if mode == "freq" {
+                        let frequency = try decodeFrequencyJson(json: data)
+
+                        if let frequency = frequency {
+                            return FrequencyData(
+                                word: term,
+                                reading: nil,
+                                frequency: frequency,
+                                rank: frequency,
+                                source: dictionaryKey
+                            )
+                        }
+                    }
+                }
+
+                return nil
+            }
+        } catch {
+            return nil
+        }
+    }
+
+    func getFrequencyData(for word: String) -> [FrequencyData] {
+        var frequencyData: [FrequencyData] = []
+
+        if let data = getBCCWJFrequencyData(for: word) {
+            frequencyData.append(data)
+        }
+
+        return frequencyData
+    }
+
     /// Get frequency rank for display (returns a formatted string)
     func getFrequencyRank(for word: String) -> String? {
-        guard let frequencyData = getFrequencyData(for: word) else { return nil }
-        
+        guard let frequencyData = getBCCWJFrequencyData(for: word) else { return nil }
+
         if frequencyData.rank > 0 {
             return "#\(frequencyData.rank)"
         } else if frequencyData.frequency > 0 {
             return "f:\(frequencyData.frequency)"
         }
-        
+
         return nil
     }
-    
+
     /// Test the BCCWJ database integration
     func testBCCWJDatabaseIntegration() {
         print("🧪 [BCCWJ TEST] Testing BCCWJ database integration...")
-        
+
         guard let db = bccwjQueue else {
             print("🧪 [BCCWJ TEST] ERROR: BCCWJ database queue is nil!")
             return
         }
-        
+
         do {
             try db.read { db in
                 // Check database structure
-                let tableRows = try Row.fetchAll(db, sql: "SELECT name FROM sqlite_master WHERE type='table'")
+                let tableRows = try Row.fetchAll(
+                    db, sql: "SELECT name FROM sqlite_master WHERE type='table'")
                 let tableNames = tableRows.map { $0["name"] as? String ?? "unknown" }
                 print("🧪 [BCCWJ TEST] Available tables: \(tableNames)")
-                
+
                 // For each table, show its structure
                 for tableName in tableNames {
                     let schemaRows = try Row.fetchAll(db, sql: "PRAGMA table_info(\(tableName))")
@@ -117,7 +205,7 @@ class FrequencyManager {
                         let type = row["type"] as? String ?? "unknown"
                         print("  - \(name): \(type)")
                     }
-                    
+
                     // Show sample data
                     let sampleRows = try Row.fetchAll(db, sql: "SELECT * FROM \(tableName) LIMIT 3")
                     print("🧪 [BCCWJ TEST] Sample data from '\(tableName)':")
@@ -130,13 +218,16 @@ class FrequencyManager {
                     }
                     print()
                 }
-                
+
                 // Test frequency lookup for common words
                 let testWords = ["猫", "日本", "最初", "食べる", "の", "は", "を", "に"]
                 print("🧪 [BCCWJ TEST] Testing frequency lookup for common words:")
                 for word in testWords {
                     // Test direct database query
-                    let directRows = try Row.fetchAll(db, sql: "SELECT term, frequency_value FROM frequency WHERE term = ? LIMIT 1", arguments: [word])
+                    let directRows = try Row.fetchAll(
+                        db,
+                        sql: "SELECT term, frequency_value FROM frequency WHERE term = ? LIMIT 1",
+                        arguments: [word])
                     if let row = directRows.first {
                         let term = row["term"] as? String ?? "unknown"
                         let freq = row["frequency_value"] as? Int ?? 0
@@ -144,13 +235,13 @@ class FrequencyManager {
                     } else {
                         print("🧪 [BCCWJ TEST] Direct query '\(word)': No match found")
                     }
-                    
+
                     // Test using our frequency manager
-                    if let frequencyData = getFrequencyData(for: word) {
-                        print("🧪 [BCCWJ TEST] FrequencyManager '\(word)': rank=\(frequencyData.rank), freq=\(frequencyData.frequency)")
-                    } else {
-                        print("🧪 [BCCWJ TEST] FrequencyManager '\(word)': No frequency data found")
-                    }
+                    //                    if let frequencyData = getFrequencyData(for: word) {
+                    //                        print("🧪 [BCCWJ TEST] FrequencyManager '\(word)': rank=\(frequencyData.rank), freq=\(frequencyData.frequency)")
+                    //                    } else {
+                    //                        print("🧪 [BCCWJ TEST] FrequencyManager '\(word)': No frequency data found")
+                    //                    }
                 }
             }
         } catch {

--- a/Shiori Reader/Services/Dictionary/FrequencyManager.swift
+++ b/Shiori Reader/Services/Dictionary/FrequencyManager.swift
@@ -89,7 +89,7 @@ class FrequencyManager {
         }
     }
 
-    /// Get the frequency number from the "data" field json string in a term bank.
+    /// Get the frequency data from the "data" field json string in a term bank.
     func decodeFrequencyJson(json jsonData: Data) -> YomitanFrequencyData? {
         let json = try! JSONSerialization.jsonObject(with: jsonData, options: [JSONSerialization.ReadingOptions.fragmentsAllowed])
         

--- a/Shiori Reader/Services/Dictionary/FrequencyManager.swift
+++ b/Shiori Reader/Services/Dictionary/FrequencyManager.swift
@@ -139,9 +139,11 @@ class FrequencyManager {
     func getImportedFrequencyData(for word: String, with reading: String, db: DatabaseQueue, dictionaryKey: String)
         -> FrequencyData?
     {
+        var rows: [Row] = []
+        
         do {
-            return try db.read { db in
-                let rows = try Row.fetchAll(
+            try db.read { db in
+                rows = try Row.fetchAll(
                     db,
                     sql: """
                         SELECT id, expression, mode, data, dictionary
@@ -149,35 +151,35 @@ class FrequencyManager {
                         WHERE expression = ?
                         ORDER BY id
                         """, arguments: [word])
+            }
 
-                for row in rows {
-                    let term = row["expression"] as! String
-                    let mode = row["mode"] as! String
-                    let data = row["data"] as! String
+            for row in rows {
+                let term = row["expression"] as! String
+                let mode = row["mode"] as! String
+                let data = row["data"] as! String
 
-                    if mode == "freq" {
-                        let jsonData = data.data(using: .utf8)!
-                        let yomitanFrequencyData = decodeFrequencyJson(json: jsonData)
+                if mode == "freq" {
+                    let jsonData = data.data(using: .utf8)!
+                    let yomitanFrequencyData = decodeFrequencyJson(json: jsonData)
 
-                        if let frequency = yomitanFrequencyData {
-                            if let frequencyReading = frequency.reading,
-                               frequencyReading != reading {
-                                continue
-                            }
-                            
-                            return FrequencyData(
-                                word: term,
-                                reading: reading,
-                                frequency: frequency.frequency,
-                                rank: frequency.frequency,
-                                source: dictionaryKey
-                            )
+                    if let frequency = yomitanFrequencyData {
+                        if let frequencyReading = frequency.reading,
+                           frequencyReading != reading {
+                            continue
                         }
+                        
+                        return FrequencyData(
+                            word: term,
+                            reading: reading,
+                            frequency: frequency.frequency,
+                            rank: frequency.frequency,
+                            source: dictionaryKey
+                        )
                     }
                 }
-
-                return nil
             }
+
+            return nil
         } catch {
             return nil
         }

--- a/Shiori Reader/Services/Dictionary/FrequencyManager.swift
+++ b/Shiori Reader/Services/Dictionary/FrequencyManager.swift
@@ -67,7 +67,7 @@ class FrequencyManager {
                             reading: nil,
                             frequency: frequencyValue,
                             rank: frequencyValue,
-                            source: "BCCWJ"
+                            source: "bccwj"
                         )
                     }
                 }

--- a/Shiori Reader/Services/Dictionary/FrequencyManager.swift
+++ b/Shiori Reader/Services/Dictionary/FrequencyManager.swift
@@ -229,11 +229,11 @@ class FrequencyManager {
                     }
 
                     // Test using our frequency manager
-                    //                    if let frequencyData = getFrequencyData(for: word) {
-                    //                        print("🧪 [BCCWJ TEST] FrequencyManager '\(word)': rank=\(frequencyData.rank), freq=\(frequencyData.frequency)")
-                    //                    } else {
-                    //                        print("🧪 [BCCWJ TEST] FrequencyManager '\(word)': No frequency data found")
-                    //                    }
+                    if let frequencyData = getBCCWJFrequencyData(for: word) {
+                        print("🧪 [BCCWJ TEST] FrequencyManager '\(word)': rank=\(frequencyData.rank), freq=\(frequencyData.frequency)")
+                    } else {
+                        print("🧪 [BCCWJ TEST] FrequencyManager '\(word)': No frequency data found")
+                    }
                 }
             }
         } catch {


### PR DESCRIPTION
<img width="528" height="155" alt="image" src="https://github.com/user-attachments/assets/8df595a8-248c-463e-ba39-6369a6aad3c6" />

I added a feature that makes imported frequency dictionaries show on dictionary entries alongside the BCCWJ entry, as visible in the screenshot above.

<b>Feature details: </b>
* Frequency dictionaries are displayed with their name and frequency value.
* Frequency dictionaries are show in the order that is set in settings
* Frequency dictionaries use the colour that is set in settings.
* If there is a word with 2 different readings, and the term reading is specified within the imported frequency dictionary, the dictionary only shows for the reading it is supposed to. This means that 2 words with the same kanji and different readings can have different frequencies.

This current implementation just takes frequency data from the term meta data and ignores pitch data. A better approach going forward would be to decode the term meta data into a structure, however this is working for now.