### PR TITLE
Added Harmonic Frequency toggle

### DIFF
--- a/Shiori Reader/Data/CoreData/ShioriReader.xcdatamodeld/ShioriReader 9.xcdatamodel/contents
+++ b/Shiori Reader/Data/CoreData/ShioriReader.xcdatamodeld/ShioriReader 9.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23788.4" systemVersion="24F74" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23788" systemVersion="24G90" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
     <entity name="AdditionalFieldEntity" representedClassName="AdditionalFieldEntity" syncable="YES" codeGenerationType="class">
         <attribute name="fieldName" optional="YES" attributeType="String"/>
         <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
@@ -21,6 +21,7 @@
         <attribute name="readingField" optional="YES" attributeType="String"/>
         <attribute name="sentenceField" optional="YES" attributeType="String"/>
         <attribute name="tags" optional="YES" attributeType="String"/>
+        <attribute name="usingHarmonicFrequency" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="wordField" optional="YES" attributeType="String"/>
         <attribute name="wordWithReadingField" optional="YES" attributeType="String"/>
         <relationship name="additionalFields" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="AdditionalFieldEntity" inverseName="ankiSettings" inverseEntity="AdditionalFieldEntity"/>

--- a/Shiori Reader/Data/CoreData/ShioriReader.xcdatamodeld/ShioriReader.xcdatamodel/contents
+++ b/Shiori Reader/Data/CoreData/ShioriReader.xcdatamodeld/ShioriReader.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23788" systemVersion="24D60" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23788" systemVersion="24G90" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
     <entity name="AdditionalFieldEntity" representedClassName="AdditionalFieldEntity" syncable="YES" codeGenerationType="class">
         <attribute name="fieldName" optional="YES" attributeType="String"/>
         <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
@@ -17,6 +17,7 @@
         <attribute name="readingField" optional="YES" attributeType="String"/>
         <attribute name="sentenceField" optional="YES" attributeType="String"/>
         <attribute name="tags" optional="YES" attributeType="String"/>
+        <attribute name="usingHarmonicFreqeuency" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="wordField" optional="YES" attributeType="String"/>
         <attribute name="wordWithReadingField" optional="YES" attributeType="String"/>
         <relationship name="additionalFields" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="AdditionalFieldEntity" inverseName="ankiSettings" inverseEntity="AdditionalFieldEntity"/>

--- a/Shiori Reader/Data/Models/AnkiSettings.swift
+++ b/Shiori Reader/Data/Models/AnkiSettings.swift
@@ -19,6 +19,7 @@ struct AnkiSettings: Identifiable, Equatable, Hashable {
     var additionalFields: [AdditionalField]
     
     // Frequency export settings
+    var usingHarmonicFrequency: Bool
     var frequencyDictionarySource: String
     
     // Cached Anki data
@@ -41,6 +42,7 @@ struct AnkiSettings: Identifiable, Equatable, Hashable {
          pitchAccentTextColor: String = "black",
          tags: String = "shiori-reader",
          additionalFields: [AdditionalField] = [],
+         usingHarmonicFrequency: Bool = false,
          frequencyDictionarySource: String = "bccwj",
          cachedDecks: [String] = [],
          cachedNoteTypes: [String: [String]] = [:]) {
@@ -59,6 +61,7 @@ struct AnkiSettings: Identifiable, Equatable, Hashable {
         self.tags = tags
         self.additionalFields = additionalFields
         self.frequencyDictionarySource = frequencyDictionarySource
+        self.usingHarmonicFrequency = usingHarmonicFrequency
         self.cachedDecks = cachedDecks
         self.cachedNoteTypes = cachedNoteTypes
     }
@@ -79,6 +82,7 @@ struct AnkiSettings: Identifiable, Equatable, Hashable {
         self.pitchAccentTextColor = entity.pitchAccentTextColor ?? "black"
         self.tags = entity.tags ?? "shiori-reader"
         self.frequencyDictionarySource = entity.frequencyDictionarySource ?? "bccwj"
+        self.usingHarmonicFrequency = entity.usingHarmonicFrequency
         
         // Convert related AdditionalFieldEntity objects to AdditionalField structs
         if let fields = entity.additionalFields as? Set<AdditionalFieldEntity> {
@@ -182,6 +186,7 @@ struct AnkiSettings: Identifiable, Equatable, Hashable {
             lhs.tags == rhs.tags &&
             lhs.additionalFields == rhs.additionalFields &&
             lhs.frequencyDictionarySource == rhs.frequencyDictionarySource &&
+            lhs.usingHarmonicFrequency == rhs.usingHarmonicFrequency &&
             lhs.cachedDecks == rhs.cachedDecks &&
             lhs.cachedNoteTypes == rhs.cachedNoteTypes
     }
@@ -203,6 +208,7 @@ struct AnkiSettings: Identifiable, Equatable, Hashable {
         entity.pitchAccentTextColor = pitchAccentTextColor
         entity.tags = tags
         entity.frequencyDictionarySource = frequencyDictionarySource
+        entity.usingHarmonicFrequency = usingHarmonicFrequency
         
         // Handle additional fields
         // First, remove old fields that aren't in the model anymore

--- a/Shiori Reader/Features/AnkiExport/AnkiSettingsView.swift
+++ b/Shiori Reader/Features/AnkiExport/AnkiSettingsView.swift
@@ -77,14 +77,14 @@ struct AnkiSettingsView: View {
                 Spacer()
                 
                 Toggle("", isOn: Binding(
-                    get: { 
+                    get: {
                         // Return true if no value has been set (first time), otherwise return stored value
                         if UserDefaults.standard.object(forKey: "showDefinitionSelectionPopup") == nil {
                             return true // Default to enabled
                         }
                         return UserDefaults.standard.bool(forKey: "showDefinitionSelectionPopup")
                     },
-                    set: { 
+                    set: {
                         UserDefaults.standard.set($0, forKey: "showDefinitionSelectionPopup")
                     }
                 ))
@@ -120,11 +120,39 @@ struct AnkiSettingsView: View {
             }
             .padding(.vertical, 6)
             
+            HStack(alignment: .top) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Harmonic Frequencies")
+                        .font(.body)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                    Text("Use a harmonic average of all enabled frequencies when exporting frequency data to Anki.")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .lineLimit(nil)
+                        .truncationMode(.tail)
+                }
+                
+                Spacer()
+                
+                Toggle("", isOn: Binding(
+                    get: {
+                        return viewModel.settings.usingHarmonicFrequency
+                    },
+                    set: {
+                        viewModel.settings.usingHarmonicFrequency = $0
+                    }
+                ))
+                .fixedSize()
+            }
+            
             // Frequency dictionary setting
             HStack(alignment: .top) {
+                let isDisabled = viewModel.settings.usingHarmonicFrequency
                 VStack(alignment: .leading, spacing: 4) {
                     Text("Frequency Dictionary")
                         .font(.body)
+                        .foregroundColor(isDisabled ? .gray : .primary)
                         .lineLimit(1)
                         .truncationMode(.tail)
                     Text("Choose which frequency dictionary to use when exporting frequency data to Anki cards.")
@@ -154,16 +182,18 @@ struct AnkiSettingsView: View {
                     HStack {
                         let selectedDictionary = viewModel.getAvailableFrequencyDictionaries().first(where: { $0.id == viewModel.settings.frequencyDictionarySource })
                         Text(selectedDictionary?.name ?? "BCCWJ (Built-in)")
-                            .foregroundColor(.blue)
+                            .foregroundColor(isDisabled ? .gray :.blue)
                             .font(.body)
                         Image(systemName: "chevron.down")
                             .font(.caption)
-                            .foregroundColor(.blue)
+                            .foregroundColor(isDisabled ? .gray :.blue)
                     }
                 }
+                .disabled(isDisabled)
                 .fixedSize()
             }
             .padding(.vertical, 6)
+            
         }
     }
     


### PR DESCRIPTION
Small change to add a toggle in the Anki Implementation settings that makes it so that the frequency field uses a harmonic mean of all enabled and available frequencies for the term when exporting to anki.